### PR TITLE
Add deluxe payment step

### DIFF
--- a/src/components/Form/VinInput/VinInput.spec.tsx
+++ b/src/components/Form/VinInput/VinInput.spec.tsx
@@ -72,11 +72,11 @@ describe('VinInput Component', () => {
         fireEvent.click(addButton);
 
         await waitFor(() => {
-            expect(mockOnChange).toHaveBeenCalledWith(expect.arrayContaining([
-                {
-                    vin: ""
-                }
-            ]));
+            expect(mockOnChange).toHaveBeenLastCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({ vin: "" })
+                ])
+            );
         });
     });
 

--- a/src/pages/Quote/BillSummary/index.tsx
+++ b/src/pages/Quote/BillSummary/index.tsx
@@ -25,7 +25,7 @@ const BillSummary: React.FC = () => {
         navigate('/agency/quote/bill-type')
     }
     const handleNextClick = () => {
-        navigate('/agency/quote/customer-info')
+        navigate('/agency/quote/deluxe-payment')
     }
 
     return (

--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -1,0 +1,66 @@
+import { Col, Row } from 'antd';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import SubmitButton from '../../../components/Form/SubmitButton';
+import { RootState } from '../../../utils/redux/store';
+import { PageHeader } from '../../style';
+
+const DeluxePayment: React.FC = () => {
+    const navigate = useNavigate();
+    const [showEmbed, setShowEmbed] = useState(false);
+    const deluxeToken = useSelector(({ auth }: RootState) => (auth.agency as any)?.deluxe_partner_token);
+
+    useEffect(() => {
+        if (showEmbed) {
+            const script = document.createElement('script');
+            script.src = 'https://hostedpaymentform.deluxe.com/v2/deluxe.js';
+            script.onload = () => {
+                const HostedForm = (window as any).HostedForm;
+                if (HostedForm) {
+                    const options = {
+                        containerId: 'deluxe-container',
+                        xtoken: deluxeToken,
+                        xrtype: 'Create Vault',
+                        xpm: '0',
+                        xdisplayvafields: 'true',
+                        xcssid: 'mycustomcss'
+                    };
+                    HostedForm.init(options, {
+                        onSuccess: (data: unknown) => {
+                            console.log(JSON.stringify(data));
+                            alert('Payment method added successfully');
+                            navigate('/agency/quote/customer-info');
+                        },
+                        onFailure: (data: unknown) => { console.log(JSON.stringify(data)); },
+                        onInvalid: (data: unknown) => { console.log(JSON.stringify(data)); }
+                    }).then((instance: any) => instance.renderHpf());
+                }
+            };
+            document.body.appendChild(script);
+            return () => {
+                document.body.removeChild(script);
+            };
+        }
+    }, [showEmbed, deluxeToken, navigate]);
+
+    return (
+        <Row gutter={[0, 20]} justify={"center"}>
+            <Col span={24} style={{ textAlign: 'center' }}>
+                <PageHeader level={2}>Add Customer To Deluxe</PageHeader>
+            </Col>
+            <Col span={24} style={{ textAlign: 'center', marginTop: '24px' }}>
+                {!showEmbed && (
+                    <SubmitButton onClick={() => setShowEmbed(true)}>
+                        Add Customer to Deluxe
+                    </SubmitButton>
+                )}
+            </Col>
+            <Col span={24}>
+                {showEmbed && <div id="deluxe-container" style={{ width: '100%' }} />}
+            </Col>
+        </Row>
+    );
+};
+
+export default DeluxePayment;

--- a/src/pages/Quote/index.tsx
+++ b/src/pages/Quote/index.tsx
@@ -23,6 +23,9 @@ const steps = [
         route: '/bill-summary'
     },
     {
+        route: '/deluxe-payment'
+    },
+    {
         route: '/customer-info'
     },
     {

--- a/src/utils/router/router.tsx
+++ b/src/utils/router/router.tsx
@@ -21,6 +21,7 @@ const CustomerPay = lazy(() => import('../../pages/Quote/CustomerPay'))
 const CustomerInfo = lazy(() => import('../../pages/Quote/CustomerInfo'))
 const Summary = lazy(() => import('../../pages/Quote/Summary'))
 const BillSummary = lazy(() => import('../../pages/Quote/BillSummary'))
+const DeluxePayment = lazy(() => import('../../pages/Quote/DeluxePayment'))
 const Quote = lazy(() => import('../../pages/Quote'))
 const Collect = lazy(() => import('../../pages/Collect'))
 const CollectSearch = lazy(() => import('../../pages/Collect/Search'))
@@ -126,6 +127,10 @@ const router = createBrowserRouter([
                             {
                                 path: 'bill-summary',
                                 element: <BillSummary />
+                            },
+                            {
+                                path: 'deluxe-payment',
+                                element: <DeluxePayment />
                             },
                             {
                                 path: 'customer-info',


### PR DESCRIPTION
## Summary
- add new DeluxePayment page for Deluxe hosted payment form
- hook DeluxePayment route into quote flow and progress steps
- update bill summary next button to go to DeluxePayment page
- fix VinInput test expectation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c855597ac832b88e69e5fc6169bb0