### PR TITLE
Add deluxe partner token mapping

### DIFF
--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -9,7 +9,7 @@ import { PageHeader } from '../../style';
 const DeluxePayment: React.FC = () => {
     const navigate = useNavigate();
     const [showEmbed, setShowEmbed] = useState(false);
-    const deluxeToken = useSelector(({ auth }: RootState) => (auth.agency as any)?.deluxe_partner_token);
+    const deluxeToken = useSelector(({ auth }: RootState) => auth.agency?.deluxePartnerToken);
 
     useEffect(() => {
         const handleMessage = (e: MessageEvent) => {

--- a/src/utils/mappers/agencyMapper.ts
+++ b/src/utils/mappers/agencyMapper.ts
@@ -16,6 +16,7 @@ const agencyMapper = (directusAgency: DirectusAgency): Agency => {
         country: directusAgency.country,
         postalCode: directusAgency.postal_code,
         routingNumber: directusAgency.routing_number,
+        deluxePartnerToken: directusAgency.deluxe_partner_token,
     }
 }
 export default agencyMapper

--- a/src/utils/types/common.ts
+++ b/src/utils/types/common.ts
@@ -40,6 +40,7 @@ export type Agency = {
     country: string | null
     postalCode: string | null
     routingNumber: string | null
+    deluxePartnerToken: string | null
 }
 
 export type User = {

--- a/src/utils/types/schema.ts
+++ b/src/utils/types/schema.ts
@@ -16,6 +16,7 @@ export interface DirectusAgency {
     country: string | null
     postal_code: string | null
     routing_number: string | null
+    deluxe_partner_token: string | null
 }
 
 export interface DirectusBill {


### PR DESCRIPTION
## Summary
- extend `DirectusAgency` and `Agency` types with `deluxePartnerToken`
- map new property in `agencyMapper`
- use the mapped token in `DeluxePayment` without a type cast

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d18a014f4832bacdf8f0e030d16c2