### PR TITLE
Add Deluxe payment origin check

### DIFF
--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -12,8 +12,9 @@ const DeluxePayment: React.FC = () => {
     const deluxeToken = useSelector(({ auth }: RootState) => (auth.agency as any)?.deluxe_partner_token);
 
     useEffect(() => {
+        const allowedOrigin = 'https://hostedpaymentform.deluxe.com';
         const handleMessage = (e: MessageEvent) => {
-            if (e.data === 'deluxe_success') {
+            if (e.origin === allowedOrigin && e.data === 'deluxe_success') {
                 alert('Payment method added successfully');
                 navigate('/agency/quote/customer-info');
             }


### PR DESCRIPTION
## Summary
- ensure `postMessage` events come from Deluxe

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d18a1280c832b8d42bdadf0fab735