### PR TITLE
Fix deluxe partner token retrieval

### DIFF
--- a/src/pages/Quote/CustomerInfo/index.tsx
+++ b/src/pages/Quote/CustomerInfo/index.tsx
@@ -20,7 +20,9 @@ import { emailRegEx } from "../../../utils/contants/regex";
 import { BillTypeEnum, CustomerPayFrequency, QuoteFrequency } from '../../../utils/enums/common';
 import billDueCalculation from '../../../utils/helpers/billDueCalculation';
 import { updateQuote } from "../../../utils/redux/slices/quoteSlice";
+import { updateAgency } from '../../../utils/redux/slices/authSlice';
 import { RootState } from '../../../utils/redux/store';
+import { getAgencyDeluxePartnerToken } from '../../../utils/apis/directus';
 import { CalculatedQuoteInstallments, VIN } from "../../../utils/types/common";
 import { InternalErrors } from "../../../utils/types/errors";
 import { CustomDirectusUser } from "../../../utils/types/schema";
@@ -65,6 +67,20 @@ const CustomerInfo: React.FC = () => {
     const deluxeToken = useSelector(({ auth }: RootState) => auth.agency?.deluxePartnerToken)
     const [calenderDays, setCalenderDays] = useState<number>()
     const [userCardsFetching, setUserCardsFetching] = useState(false)
+
+    useEffect(() => {
+        const fetchToken = async () => {
+            if (!deluxeToken && agencyId) {
+                try {
+                    const token = await getAgencyDeluxePartnerToken(directusClient, agencyId)
+                    dispatch(updateAgency({ deluxePartnerToken: token }))
+                } catch (err) {
+                    console.error(err)
+                }
+            }
+        }
+        fetchToken()
+    }, [deluxeToken, agencyId, directusClient, dispatch])
     const fetchUserCards = useCallback(async (customerId: string) => {
         if (agencyId) {
             try {

--- a/src/pages/Quote/DeluxePayment/index.spec.tsx
+++ b/src/pages/Quote/DeluxePayment/index.spec.tsx
@@ -5,6 +5,14 @@ import { ThemeProvider } from 'styled-components';
 import DeluxePayment from '.';
 import { useNavigate } from 'react-router-dom';
 
+jest.mock('../../../components/DirectUs/DirectusContext', () => ({
+    useDirectUs: () => ({ directusClient: {} }),
+}));
+
+jest.mock('../../../utils/apis/directus', () => ({
+    getAgencyDeluxePartnerToken: jest.fn(() => Promise.resolve('TOKEN123')),
+}));
+
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: jest.fn(),

--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -4,8 +4,11 @@ import { LuArrowRight } from 'react-icons/lu';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import SubmitButton from '../../../components/Form/SubmitButton';
+import { useDirectUs } from '../../../components/DirectUs/DirectusContext';
 import { resetQuote } from '../../../utils/redux/slices/quoteSlice';
+import { updateAgency } from '../../../utils/redux/slices/authSlice';
 import { RootState } from '../../../utils/redux/store';
+import { getAgencyDeluxePartnerToken } from '../../../utils/apis/directus';
 import { PageHeader } from '../../style';
 
 const DeluxePayment: React.FC = () => {
@@ -13,6 +16,22 @@ const DeluxePayment: React.FC = () => {
     const dispatch = useDispatch();
     const [showEmbed, setShowEmbed] = useState(false);
     const deluxeToken = useSelector(({ auth }: RootState) => auth.agency?.deluxePartnerToken);
+    const agencyId = useSelector(({ auth }: RootState) => auth.agency?.id);
+    const { directusClient } = useDirectUs();
+
+    useEffect(() => {
+        const fetchToken = async () => {
+            if (!deluxeToken && agencyId) {
+                try {
+                    const token = await getAgencyDeluxePartnerToken(directusClient, agencyId);
+                    dispatch(updateAgency({ deluxePartnerToken: token }));
+                } catch (err) {
+                    console.error(err);
+                }
+            }
+        }
+        fetchToken();
+    }, [deluxeToken, agencyId, directusClient, dispatch]);
 
     const handleResetClick = () => {
         dispatch(resetQuote());

--- a/src/utils/apis/directus/index.ts
+++ b/src/utils/apis/directus/index.ts
@@ -57,6 +57,15 @@ export const logout = async (client: DirectusContextClient) => {
 
     }
 }
+
+export const getAgencyDeluxePartnerToken = async (client: DirectusContextClient, agencyId: number) => {
+    try {
+        const agency = await client.request(readItem('agency', agencyId, { fields: ['deluxe_partner_token'] }));
+        return (agency as DirectusAgency).deluxe_partner_token;
+    } catch (error) {
+        throw parseDirectUsErrors(error as DirectusError);
+    }
+}
 export const findCustomerByEmail = async (client: DirectusContextClient, email: string) => {
     try {
         const users = await client.request(readUsers({

--- a/src/utils/redux/slices/authSlice.ts
+++ b/src/utils/redux/slices/authSlice.ts
@@ -47,11 +47,20 @@ export const authSlice = createSlice({
                 }
             }
         },
+        updateAgency(state, action: PayloadAction<Partial<Agency>>) {
+            return {
+                ...state,
+                agency: {
+                    ...state.agency,
+                    ...action.payload,
+                } as Agency | undefined,
+            }
+        },
         logoutAction() {
             return cloneDeep(authReducerInitialState)
         },
     },
 });
 
-export const { agencyLoginAction, customerLoginAction, updateUser, logoutAction } = authSlice.actions;
+export const { agencyLoginAction, customerLoginAction, updateUser, updateAgency, logoutAction } = authSlice.actions;
 export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- expose `getAgencyDeluxePartnerToken` for Directus API
- add `updateAgency` action to store agency changes
- load Deluxe partner token when opening DeluxePayment page
- ensure CustomerInfo fetches partner token if missing
- mock Directus modules in DeluxePayment tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d595abb6c832bb79cc11a071772d5