### PR TITLE
Fix Deluxe iframe message handling

### DIFF
--- a/src/pages/Quote/DeluxePayment/index.spec.tsx
+++ b/src/pages/Quote/DeluxePayment/index.spec.tsx
@@ -77,7 +77,7 @@ describe('DeluxePayment Page', () => {
         const nextButton = screen.getByRole('button', { name: /Next/i });
         expect(nextButton).toBeDisabled();
 
-        window.dispatchEvent(new MessageEvent('message', { data: { event: 'deluxe_success', payload: { data: 'x' } }, origin: 'https://hostedpaymentform.deluxe.com' }));
+        window.dispatchEvent(new MessageEvent('message', { data: { event: 'deluxe_success', payload: { data: 'x' } }, origin: 'null' }));
 
         await waitFor(() => {
             expect(nextButton).toBeEnabled();

--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -43,9 +43,8 @@ const DeluxePayment: React.FC = () => {
     };
 
     useEffect(() => {
-        const allowedOrigin = 'https://hostedpaymentform.deluxe.com';
         const handleMessage = (e: MessageEvent) => {
-            if (e.origin === allowedOrigin && e.data?.event === 'deluxe_success') {
+            if (e.data?.event === 'deluxe_success') {
                 sessionStorage.setItem('deluxeData', JSON.stringify(e.data.payload));
                 alert('Payment method added successfully');
                 setIsPaymentAdded(true);


### PR DESCRIPTION
## Summary
- remove strict origin check for Deluxe message
- update test to match new message origin

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e78f8a738832bbbdd30b90843fe6c