### PR TITLE
Fix deluxe ID parsing and update existing customers

### DIFF
--- a/src/pages/Quote/CustomerInfo/index.tsx
+++ b/src/pages/Quote/CustomerInfo/index.tsx
@@ -114,20 +114,16 @@ const CustomerInfo: React.FC = () => {
         }
     }, [quote.dueMonth])
     const getCustomer = useCallback(async (values: CustomerInfoForm, deluxe?: { deluxeCustomerId?: string, deluxeVaultId?: string }) => {
-        let customer: CustomDirectusUser
-        if (selectedCustomer) {
-            customer = selectedCustomer
-        } else {
-            customer = await findOrCreateCustomerSearchByEmail(directusClient, values.customerEmail, {
-                first_name: values.customerFirstName,
-                last_name: values.customerLastName,
-                phone: values.customerPhone,
-                deluxe_customer_id: deluxe?.deluxeCustomerId,
-                deluxe_vault_id: deluxe?.deluxeVaultId
-            })
-        }
+        const customer = await findOrCreateCustomerSearchByEmail(directusClient, values.customerEmail, {
+            first_name: values.customerFirstName,
+            last_name: values.customerLastName,
+            phone: values.customerPhone,
+            deluxe_customer_id: deluxe?.deluxeCustomerId,
+            deluxe_vault_id: deluxe?.deluxeVaultId
+        })
+
         return customer
-    }, [directusClient, selectedCustomer])
+    }, [directusClient])
 
     const validateForm = useCallback((values: CustomerInfoForm) => {
         if (quote.quoteType === BillTypeEnum.AUTO_INSURANCE && values.vins.some(vin => vin.errorCode !== '0')) {
@@ -171,8 +167,8 @@ const CustomerInfo: React.FC = () => {
                 if (deluxeDataStr) {
                     try {
                         const deluxeInfo = JSON.parse(deluxeDataStr)
-                        deluxeCustomerId = deluxeInfo.customerId || deluxeInfo.customer_id || deluxeInfo.CustomerId
-                        deluxeVaultId = deluxeInfo.vaultId || deluxeInfo.vault_id || deluxeInfo.VaultId
+                        deluxeCustomerId = deluxeInfo?.data?.customerId
+                        deluxeVaultId = deluxeInfo?.data?.vaultId
                     } catch (err) {
                         console.error(err)
                     }

--- a/src/utils/apis/directus/index.ts
+++ b/src/utils/apis/directus/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { aggregate, createItem, createItems, createUser, DirectusRole, readItem, readItems, readMe, readRoles, readUsers, triggerFlow, updateItem, updateMe } from '@directus/sdk';
+import { aggregate, createItem, createItems, createUser, DirectusRole, readItem, readItems, readMe, readRoles, readUsers, triggerFlow, updateItem, updateMe, updateUser } from '@directus/sdk';
 import moment from 'moment';
 import { Roles } from '../../enums/common';
 import InvalidCredentialsError from '../../errors/InvalidCredentials';
@@ -101,6 +101,21 @@ export const findCustomerByPhone = async (client: DirectusContextClient, phone: 
 export const findOrCreateCustomerSearchByEmail = async (client: DirectusContextClient, email: string, data?: Partial<CustomDirectusUser> = {}) => {
     const user = await findCustomerByEmail(client, email)
     if (user) {
+        if (data?.deluxe_customer_id || data?.deluxe_vault_id) {
+            try {
+                await client.request(updateUser(user.id, {
+                    deluxe_customer_id: data?.deluxe_customer_id,
+                    deluxe_vault_id: data?.deluxe_vault_id
+                }))
+                return {
+                    ...user,
+                    deluxe_customer_id: data?.deluxe_customer_id ?? user.deluxe_customer_id,
+                    deluxe_vault_id: data?.deluxe_vault_id ?? user.deluxe_vault_id
+                } as CustomDirectusUser
+            } catch (error) {
+                throw parseDirectUsErrors(error as DirectusError)
+            }
+        }
         return user
     }
 


### PR DESCRIPTION
## Summary
- parse deluxe info from `deluxeInfo.data` when available
- always create or update customer records with deluxe IDs
- update `findOrCreateCustomerSearchByEmail` to update deluxe IDs on existing users

## Testing
- `npm test` *(fails: DeluxePayment tests)*

------
https://chatgpt.com/codex/tasks/task_e_68509548b3e8832b8576cb44949f8ee5