### PR TITLE
Fix Deluxe Payment Next button logic

### DIFF
--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -125,8 +125,9 @@ const DeluxePayment: React.FC = () => {
                         <SubmitButton danger onClick={handleResetClick}>Start Over</SubmitButton>
                     </Col>
                     <Col>
-                        {/*<SubmitButton icon={<LuArrowRight />} onClick={handleNextClick} disabled={!isPaymentAdded}>Next</SubmitButton>*/}
-                        <SubmitButton icon={<LuArrowRight />} onClick={handleNextClick}>Next</SubmitButton>
+                        <SubmitButton icon={<LuArrowRight />} onClick={handleNextClick} disabled={!isPaymentAdded}>
+                            Next
+                        </SubmitButton>
                     </Col>
                 </Row>
             </Col>


### PR DESCRIPTION
## Summary
- require Deluxe payment added before enabling "Next" button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850954cfd20832bb5e7868c5afc50b6