### PR TITLE
Fix Deluxe Payment Next button logic

### DIFF
--- a/src/pages/Quote/DeluxePayment/index.spec.tsx
+++ b/src/pages/Quote/DeluxePayment/index.spec.tsx
@@ -77,7 +77,12 @@ describe('DeluxePayment Page', () => {
         const nextButton = screen.getByRole('button', { name: /Next/i });
         expect(nextButton).toBeDisabled();
 
-        window.dispatchEvent(new MessageEvent('message', { data: { event: 'deluxe_success', payload: { data: 'x' } }, origin: 'null' }));
+        window.dispatchEvent(
+            new MessageEvent('message', {
+                data: { type: 'Vault', data: { customerId: '123', vaultId: 'abc' } },
+                origin: 'null',
+            })
+        );
 
         await waitFor(() => {
             expect(nextButton).toBeEnabled();

--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -44,8 +44,17 @@ const DeluxePayment: React.FC = () => {
 
     useEffect(() => {
         const handleMessage = (e: MessageEvent) => {
-            if (e.data?.event === 'deluxe_success') {
-                sessionStorage.setItem('deluxeData', JSON.stringify(e.data.payload));
+            const data = e.data as any;
+            const isVaultMessage =
+                data && typeof data === 'object' && data.type === 'Vault';
+            const isSuccessEvent =
+                data && typeof data === 'object' && data.event === 'deluxe_success';
+
+            if (isSuccessEvent || isVaultMessage) {
+                const payload = isVaultMessage
+                    ? { customerId: data.data?.customerId, vaultId: data.data?.vaultId }
+                    : data.payload;
+                sessionStorage.setItem('deluxeData', JSON.stringify(payload));
                 alert('Payment method added successfully');
                 setIsPaymentAdded(true);
             }
@@ -125,8 +134,9 @@ const DeluxePayment: React.FC = () => {
                         <SubmitButton danger onClick={handleResetClick}>Start Over</SubmitButton>
                     </Col>
                     <Col>
-                        {/*<SubmitButton icon={<LuArrowRight />} onClick={handleNextClick} disabled={!isPaymentAdded}>Next</SubmitButton>*/}
-                        <SubmitButton icon={<LuArrowRight />} onClick={handleNextClick}>Next</SubmitButton>
+                        <SubmitButton icon={<LuArrowRight />} onClick={handleNextClick} disabled={!isPaymentAdded}>
+                            Next
+                        </SubmitButton>
                     </Col>
                 </Row>
             </Col>


### PR DESCRIPTION
## Summary
- require Deluxe payment added before enabling "Next" button
- handle Deluxe iframe message without using `event` field
- update tests for new message structure

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850954cfd20832bb5e7868c5afc50b6