### PR TITLE
Update payment to trigger deluxe flows

### DIFF
--- a/src/pages/Collect/Payment/index.tsx
+++ b/src/pages/Collect/Payment/index.tsx
@@ -10,7 +10,7 @@ import DueNow from "../../../components/DueNow";
 import FormItem from "../../../components/Form/FormItem";
 import SubmitButton from "../../../components/Form/SubmitButton";
 import TabRadioSelection from "../../../components/Form/TabRadioSelection";
-import { captureACHPayment, captureCardPayment, recordCashPayment } from "../../../utils/apis/directus";
+import { captureACHPayment, captureCardPayment, recordCashPayment, captureDeluxeACHPayment, captureDeluxeCardPayment } from "../../../utils/apis/directus";
 import { getCustomerPaymentSources } from '../../../utils/apis/directus/index';
 import { PaymentType, Roles } from "../../../utils/enums/common";
 import { RootState } from "../../../utils/redux/store";
@@ -119,6 +119,12 @@ const Payment = () => {
                     cardId,
                     enableAutoPayment
                 })
+            await captureDeluxeCardPayment(
+                directusClient,
+                {
+                    paymentId: duePayment?.id as number
+                }
+            )
             navigate(successUrl, { replace: true })
         } catch (error) {
             message.error((error as InternalErrors).message)
@@ -150,6 +156,12 @@ const Payment = () => {
                         cvv: values.cvv,
                         enableAutoPayment
                     })
+                await captureDeluxeCardPayment(
+                    directusClient,
+                    {
+                        paymentId: payment.id
+                    }
+                )
                 navigate(successUrl, { replace: true })
             } catch (error) {
                 message.error((error as InternalErrors).message)
@@ -176,6 +188,12 @@ const Payment = () => {
                         accountNumber: values.account,
                         routingNumber: values.routing,
                         enableAutoPayment
+                    }
+                )
+                await captureDeluxeACHPayment(
+                    directusClient,
+                    {
+                        paymentId: payment.id
                     }
                 )
                 navigate(successUrl, { replace: true })
@@ -211,6 +229,12 @@ const Payment = () => {
                     accountId,
                     enableAutoPayment
                 })
+            await captureDeluxeACHPayment(
+                directusClient,
+                {
+                    paymentId: duePayment?.id as number
+                }
+            )
             navigate(successUrl, { replace: true })
         } catch (error) {
             message.error((error as InternalErrors).message)

--- a/src/utils/apis/directus/index.ts
+++ b/src/utils/apis/directus/index.ts
@@ -440,6 +440,25 @@ export const captureCardPayment = async (
     }
 
 }
+
+export const captureDeluxeCardPayment = async (
+    client: DirectusContextClient,
+    payload: {
+        paymentId: number
+    }) => {
+    try {
+        const res = await client.request(triggerFlow('POST', 'd8acd9a4-1917-4252-80d3-d11e602fd932', payload));
+
+        if (res.errors && res.errors.length > 0) {
+            throw res
+        } else if (!res.errors && res.status > 299) {
+            throw formatError(res)
+        }
+    } catch (error) {
+        throw parseDirectUsErrors(error as DirectusError)
+    }
+
+}
 export const updateBillStatus = async (
     client: DirectusContextClient,
     billId: number,
@@ -648,6 +667,25 @@ export const captureACHPayment = async (
         } else if (!res.errors && res.status > 299) {
             throw formatError(res)
 
+        }
+    } catch (error) {
+        throw parseDirectUsErrors(error as DirectusError)
+    }
+
+}
+
+export const captureDeluxeACHPayment = async (
+    client: DirectusContextClient,
+    payload: {
+        paymentId: number
+    }) => {
+    try {
+        const res = await client.request(triggerFlow('POST', '15c1fbc3-db05-4940-ac04-193964544ef8', payload));
+
+        if (res.errors && res.errors.length > 0) {
+            throw res
+        } else if (!res.errors && res.status > 299) {
+            throw formatError(res)
         }
     } catch (error) {
         throw parseDirectUsErrors(error as DirectusError)


### PR DESCRIPTION
## Summary
- trigger additional Deluxe card and ACH flows when collecting payment
- expose new Deluxe flow helpers in Directus API wrapper

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879f1cfcc34832b9996ab11cb579e1f