### PR TITLE
Add Directus flow and test page

### DIFF
--- a/src/pages/FlowTest/index.tsx
+++ b/src/pages/FlowTest/index.tsx
@@ -1,0 +1,33 @@
+import { Button } from 'antd';
+import React, { useState } from 'react';
+import { useDirectUs } from '../../components/DirectUs/DirectusContext';
+import { fetchCustomerAgencyFlow } from '../../utils/apis/directus';
+
+const FlowTest: React.FC = () => {
+    const { directusClient } = useDirectUs();
+    const [response, setResponse] = useState<any>(null);
+
+    const handleClick = async () => {
+        try {
+            const res = await fetchCustomerAgencyFlow(directusClient, {
+                agency: '38',
+                customer_id: 'c2588d23-b486-419c-bd8f-306d849a2e21',
+            });
+            setResponse(res);
+            console.log(res);
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    return (
+        <div style={{ padding: 24 }}>
+            <Button onClick={handleClick}>Trigger Flow</Button>
+            {response && (
+                <pre>{JSON.stringify(response, null, 2)}</pre>
+            )}
+        </div>
+    );
+};
+
+export default FlowTest;

--- a/src/utils/apis/directus/index.ts
+++ b/src/utils/apis/directus/index.ts
@@ -848,3 +848,22 @@ export const fetchPaymentWithToken = async (
 
 }
 
+export const fetchCustomerAgencyFlow = async (
+    client: DirectusContextClient,
+    payload: {
+        customer_id: string,
+        agency: string
+    }) => {
+    try {
+        const res = await client.request(triggerFlow('GET', '00cdf064-e022-49c8-b91d-8568e6daca78', payload));
+        if (res.errors && res.errors.length > 0) {
+            throw res;
+        } else if (!res.errors && res.status > 299) {
+            throw formatError(res);
+        }
+        return res;
+    } catch (error) {
+        throw parseDirectUsErrors(error as DirectusError);
+    }
+}
+

--- a/src/utils/router/router.tsx
+++ b/src/utils/router/router.tsx
@@ -32,6 +32,7 @@ const ChangesDue = lazyWithRetry(() => import('../../pages/Collect/ChangesDue'))
 const CollectSuccess = lazyWithRetry(() => import('../../pages/Collect/Success'))
 const CollectError = lazyWithRetry(() => import('../../pages/Collect/Error'))
 const Manage = lazyWithRetry(() => import('../../pages/Manage'))
+const FlowTest = lazyWithRetry(() => import('../../pages/FlowTest'))
 
 const router = createBrowserRouter([
     {
@@ -61,6 +62,12 @@ const router = createBrowserRouter([
             {
                 path: "reset-password/error",
                 element: <ResetPasswordError />,
+            },
+            {
+                path: "flow-test",
+                element: <AuthenticationWrapper>
+                    <FlowTest />
+                </AuthenticationWrapper>,
             },
             {
                 path: "my-bills",


### PR DESCRIPTION
## Summary
- add Directus utility to trigger new flow requiring customer and agency IDs
- create simple FlowTest page with button to invoke the flow
- register FlowTest page in router for easy manual testing
- wrap FlowTest route with AuthenticationWrapper so flow calls carry logged-in credentials

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ae283bd7c832b8e9510dcc1bf47e3