### PR TITLE
fix: secure flow-test route with auth wrapper

### DIFF
--- a/src/utils/router/router.tsx
+++ b/src/utils/router/router.tsx
@@ -65,7 +65,9 @@ const router = createBrowserRouter([
             },
             {
                 path: "flow-test",
-                element: <FlowTest />,
+                element: <AuthenticationWrapper>
+                    <FlowTest />
+                </AuthenticationWrapper>,
             },
             {
                 path: "my-bills",


### PR DESCRIPTION
## Summary
- require auth for flow-test page by wrapping route with AuthenticationWrapper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0117e8f4832b8aac5c8fa68a6f35