### PR TITLE
Add NotFound page and route

### DIFF
--- a/src/components/AuhenticationWrapper/index.tsx
+++ b/src/components/AuhenticationWrapper/index.tsx
@@ -14,7 +14,7 @@ const AuthenticationWrapper: React.FC<PropsWithChildren<{
         if (loggedInRole === role) {
             return <>{children}</>
         }
-        return <Navigate to="/404" replace />
+        return <Navigate replace to='/404' />
     }
     return <Navigate to="/login" replace />
 }

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+
+const NotFound: React.FC = () => {
+    return <div>Page not found</div>
+}
+
+export default NotFound

--- a/src/utils/router/router.tsx
+++ b/src/utils/router/router.tsx
@@ -33,6 +33,7 @@ const CollectSuccess = lazyWithRetry(() => import('../../pages/Collect/Success')
 const CollectError = lazyWithRetry(() => import('../../pages/Collect/Error'))
 const Manage = lazyWithRetry(() => import('../../pages/Manage'))
 const FlowTest = lazyWithRetry(() => import('../../pages/FlowTest'))
+const NotFound = lazyWithRetry(() => import('../../pages/NotFound'))
 
 const router = createBrowserRouter([
     {
@@ -189,6 +190,14 @@ const router = createBrowserRouter([
                         element: <AuthenticationWrapper role={Roles.AGENCY}><Manage /></AuthenticationWrapper>,
                     }
                 ]
+            },
+            {
+                path: "404",
+                element: <NotFound />,
+            },
+            {
+                path: "*",
+                element: <Navigate to='/404' replace />,
             }
         ]
     },


### PR DESCRIPTION
## Summary
- add simple NotFound page
- register /404 and catch-all routes
- update AuthenticationWrapper to redirect to new not found route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b0a315a3c832b9596b561a6246eb6