### PR TITLE
Add global route error boundary

### DIFF
--- a/src/components/RouteError/index.tsx
+++ b/src/components/RouteError/index.tsx
@@ -1,0 +1,24 @@
+import { Button } from 'antd';
+import React from 'react';
+import { useNavigate, useRouteError } from 'react-router-dom';
+
+const RouteError: React.FC = () => {
+    const error = useRouteError() as { statusText?: string; message?: string };
+    const navigate = useNavigate();
+
+    const handleHome = () => {
+        navigate('/', { replace: true });
+    };
+
+    return (
+        <div style={{ padding: 24, textAlign: 'center' }}>
+            <h1>Something went wrong</h1>
+            <p>{error?.statusText || error?.message || 'An unexpected error occurred.'}</p>
+            <Button type="primary" onClick={handleHome} style={{ marginTop: 16 }}>
+                Go to Home
+            </Button>
+        </div>
+    );
+};
+
+export default RouteError;

--- a/src/utils/router/router.tsx
+++ b/src/utils/router/router.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, Navigate } from "react-router-dom";
 import AuthenticationWrapper from "../../components/AuhenticationWrapper";
 import BoxContainer from "../../components/BoxContainer";
 import LayoutProvider from "../../components/LayoutProvider";
+import RouteError from "../../components/RouteError";
 import { Roles } from "../enums/common";
 
 const Login = lazyWithRetry(() => import('../../pages/Login'))
@@ -38,6 +39,7 @@ const router = createBrowserRouter([
     {
         path: "/",
         element: <LayoutProvider />,
+        errorElement: <RouteError />,
         children: [
             {
                 path: "/",


### PR DESCRIPTION
## Summary
- add RouteError component to display custom messages for unexpected errors
- configure router with a root-level errorElement so child routes like `/flow-test` use the custom error UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b0a3160fc832bb89e03019f25cde2