### PR TITLE
Move FlowTest route under agency section

### DIFF
--- a/src/utils/router/router.tsx
+++ b/src/utils/router/router.tsx
@@ -67,12 +67,6 @@ const router = createBrowserRouter([
                 element: <ResetPasswordError />,
             },
             {
-                path: "flow-test",
-                element: <AuthenticationWrapper>
-                    <FlowTest />
-                </AuthenticationWrapper>,
-            },
-            {
                 path: "my-bills",
                 element: <AuthenticationWrapper>
                     <MyBills />
@@ -117,6 +111,10 @@ const router = createBrowserRouter([
                     {
                         path: "profile",
                         element: <AuthenticationWrapper role={Roles.AGENCY}><AgencyProfile /></AuthenticationWrapper>,
+                    },
+                    {
+                        path: "flow-test",
+                        element: <AuthenticationWrapper role={Roles.AGENCY}><FlowTest /></AuthenticationWrapper>,
                     },
                     {
                         path: "quote",


### PR DESCRIPTION
## Summary
- Move FlowTest route to `/agency/flow-test` so it uses agency auth
- Remove top-level FlowTest route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b0dfe9180832bb0e206420e0013f2