### PR TITLE
feat: add flow test page for new directus flow

### DIFF
--- a/src/pages/FlowTest2/index.tsx
+++ b/src/pages/FlowTest2/index.tsx
@@ -1,0 +1,33 @@
+import { Button } from 'antd';
+import React, { useState } from 'react';
+import { useDirectUs } from '../../components/DirectUs/DirectusContext';
+import { fetchCustomerAgencyFlowNew } from '../../utils/apis/directus';
+
+const FlowTest2: React.FC = () => {
+    const { directusClient } = useDirectUs();
+    const [response, setResponse] = useState<any>(null);
+
+    const handleClick = async () => {
+        try {
+            const res = await fetchCustomerAgencyFlowNew(directusClient, {
+                agency: '38',
+                customer_id: 'c2588d23-b486-419c-bd8f-306d849a2e21',
+            });
+            setResponse(res);
+            console.log(res);
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    return (
+        <div style={{ padding: 24 }}>
+            <Button onClick={handleClick}>Trigger Flow</Button>
+            {response && (
+                <pre>{JSON.stringify(response, null, 2)}</pre>
+            )}
+        </div>
+    );
+};
+
+export default FlowTest2;

--- a/src/utils/apis/directus/index.ts
+++ b/src/utils/apis/directus/index.ts
@@ -867,3 +867,21 @@ export const fetchCustomerAgencyFlow = async (
     }
 }
 
+export const fetchCustomerAgencyFlowNew = async (
+    client: DirectusContextClient,
+    payload: {
+        customer_id: string,
+        agency: string
+    }) => {
+    try {
+        const res = await client.request(triggerFlow('GET', 'b578265a-905b-41d4-a19c-fbc47a260600', payload));
+        if (res.errors && res.errors.length > 0) {
+            throw res;
+        } else if (!res.errors && res.status > 299) {
+            throw formatError(res);
+        }
+        return res;
+    } catch (error) {
+        throw parseDirectUsErrors(error as DirectusError);
+    }
+}

--- a/src/utils/router/router.tsx
+++ b/src/utils/router/router.tsx
@@ -34,6 +34,7 @@ const CollectSuccess = lazyWithRetry(() => import('../../pages/Collect/Success')
 const CollectError = lazyWithRetry(() => import('../../pages/Collect/Error'))
 const Manage = lazyWithRetry(() => import('../../pages/Manage'))
 const FlowTest = lazyWithRetry(() => import('../../pages/FlowTest'))
+const FlowTest2 = lazyWithRetry(() => import('../../pages/FlowTest2'))
 const NotFound = lazyWithRetry(() => import('../../pages/NotFound'))
 
 const router = createBrowserRouter([
@@ -115,6 +116,10 @@ const router = createBrowserRouter([
                     {
                         path: "flow-test",
                         element: <AuthenticationWrapper role={Roles.AGENCY}><FlowTest /></AuthenticationWrapper>,
+                    },
+                    {
+                        path: "flow-test-2",
+                        element: <AuthenticationWrapper role={Roles.AGENCY}><FlowTest2 /></AuthenticationWrapper>,
                     },
                     {
                         path: "quote",


### PR DESCRIPTION
## Summary
- add FlowTest2 page to trigger alternate Directus flow
- support new flow via fetchCustomerAgencyFlowNew API helper
- register FlowTest2 route in router

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2609f6b38832b8e7060eea365cd8b