### PR TITLE
feat: add deluxe modal for new payment methods

### DIFF
--- a/src/pages/Collect/Payment/CardPayment.tsx
+++ b/src/pages/Collect/Payment/CardPayment.tsx
@@ -1,14 +1,8 @@
 import { Col, Row, Switch } from 'antd';
 import FeesInfoCard from '../../../components/FeesInfoCard';
-import CardNumberInput from '../../../components/Form/CardNumberInput';
-import CVVInput from '../../../components/Form/CVVInput';
-import ExpiryDateInput from '../../../components/Form/ExpiryDateInput';
-import FormItem from '../../../components/Form/FormItem';
+import SubmitButton from '../../../components/Form/SubmitButton';
 import UserCards from '../../../components/UserCards';
 import { Card, PaymentRecordingWith } from '../../../utils/types/common';
-import cardNumberValidator from '../../../utils/validators/cardNumberValidator';
-import expiryDateValidator from '../../../utils/validators/expiryDateValidator';
-import { PageSubHeader } from '../../style';
 import { ChangeAccountInfoText } from './style';
 const CardPayment = (props: {
     autoPayment: boolean,
@@ -17,53 +11,15 @@ const CardPayment = (props: {
     cards?: Card[],
     onCardSelect?: (cardId: string) => void
     paymentRecordingWith: PaymentRecordingWith
-    amount?: number
+    amount?: number,
+    onAddCard?: () => void
 }) => {
     return <Row justify={'center'} gutter={[12, 24]}>
         <Col span={24}>
             <UserCards loading={props.loading} cards={props.cards} agencyId={null} selectMode onSelect={props.onCardSelect} paymentRecordingWith={props.paymentRecordingWith} />
         </Col>
-        <Col>
-            <PageSubHeader>OR</PageSubHeader>
-        </Col>
-        <Col span={24}>
-            <FormItem
-                label="Card Number"
-                name="cardNumber"
-                rules={[
-                    {
-                        required: true
-                    },
-                    {
-                        validator: cardNumberValidator
-                    }
-                ]}
-            >
-                <CardNumberInput />
-            </FormItem>
-        </Col>
-        <Col span={12}>
-            <FormItem
-                label="Exp"
-                name="expiry"
-                rules={[
-                    {
-                        validator: expiryDateValidator
-                    }
-                ]}
-            >
-                <ExpiryDateInput />
-            </FormItem>
-        </Col>
-        <Col span={12}>
-            <FormItem
-                label="CVV"
-                name="cvv"
-                rules={[{ required: true }]}
-
-            >
-                <CVVInput />
-            </FormItem>
+        <Col span={24} style={{ textAlign: 'center' }}>
+            <SubmitButton htmlType="button" onClick={props.onAddCard}>Add New Card</SubmitButton>
         </Col>
         <Col>
             <ChangeAccountInfoText>

--- a/src/pages/Collect/Payment/DirectDebitPayment.tsx
+++ b/src/pages/Collect/Payment/DirectDebitPayment.tsx
@@ -1,10 +1,8 @@
 import { Col, Row, Switch } from 'antd';
 import FeesInfoCard from '../../../components/FeesInfoCard';
-import FormItem from '../../../components/Form/FormItem';
-import TextField from '../../../components/Form/TextField';
+import SubmitButton from '../../../components/Form/SubmitButton';
 import UserAccounts from '../../../components/UserAccounts';
 import { BankAccount, PaymentRecordingWith } from '../../../utils/types/common';
-import { PageSubHeader } from '../../style';
 import { ChangeAccountInfoText } from './style';
 const DirectDebitPayment = (props: {
     autoPayment: boolean,
@@ -13,36 +11,15 @@ const DirectDebitPayment = (props: {
     bankAccounts?: BankAccount[],
     onAccountSelect?: (accountId: string) => void,
     paymentRecordingWith: PaymentRecordingWith
-    amount?: number
+    amount?: number,
+    onAddAccount?: () => void
 }) => {
     return <Row justify={'center'} gutter={[0, 24]}>
         <Col span={24}>
             <UserAccounts loading={props.loading} bankAccounts={props.bankAccounts} agencyId={null} selectMode onSelect={props.onAccountSelect} paymentRecordingWith={props.paymentRecordingWith} />
         </Col>
-        <Col>
-            <PageSubHeader>OR</PageSubHeader>
-        </Col>
-        <Col span={24}>
-            <FormItem
-                label="Routing #"
-                name="routing"
-                rules={[{
-                    required: true
-                }]}
-            >
-                <TextField />
-            </FormItem>
-        </Col>
-        <Col span={24}>
-            <FormItem
-                label="Account #"
-                name="account"
-                rules={[{
-                    required: true
-                }]}
-            >
-                <TextField />
-            </FormItem>
+        <Col span={24} style={{ textAlign: 'center' }}>
+            <SubmitButton htmlType="button" onClick={props.onAddAccount}>Add New Account Information</SubmitButton>
         </Col>
         <Col>
             <ChangeAccountInfoText>


### PR DESCRIPTION
## Summary
- replace manual card and account forms with "Add New" buttons
- open Deluxe payment modal to capture new methods and refresh saved payment sources

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27b6ed000832b84aed2732de91b0d