### PR TITLE
Set deluxe embed xpm based on payment method

### DIFF
--- a/src/components/DeluxePaymentModal/index.tsx
+++ b/src/components/DeluxePaymentModal/index.tsx
@@ -10,7 +10,8 @@ const DeluxePaymentModal: React.FC<{
     open?: boolean;
     onClose?: () => void;
     onPaymentAdd?: () => void;
-}> = ({ open, onClose, onPaymentAdd }) => {
+    xpm?: number;
+}> = ({ open, onClose, onPaymentAdd, xpm = 0 }) => {
     const dispatch = useDispatch();
     const { directusClient } = useDirectUs();
     const deluxeToken = useSelector(({ auth }: RootState) => auth.agency?.deluxePartnerToken);
@@ -99,7 +100,7 @@ const DeluxePaymentModal: React.FC<{
     containerId: "mycontainer",
     xtoken: "${deluxeToken}",
     xrtype: "Create Vault",
-    xpm: "0",
+    xpm: "${xpm}",
     xcssid: "mycustomcss"
   };
 
@@ -113,7 +114,7 @@ const DeluxePaymentModal: React.FC<{
 </script>
 </body>
 </html>`;
-    }, [deluxeToken]);
+    }, [deluxeToken, xpm]);
 
     return (
         <CustomModal

--- a/src/components/UserAccounts/index.tsx
+++ b/src/components/UserAccounts/index.tsx
@@ -105,7 +105,7 @@ const UserAccounts: React.FC<{
                     </Row>
                 </>
             }
-            <DeluxePaymentModal open={showAddAccount} onClose={() => setShowAddAccount(false)} onPaymentAdd={handleOnAccountAdd} />
+            <DeluxePaymentModal open={showAddAccount} onClose={() => setShowAddAccount(false)} onPaymentAdd={handleOnAccountAdd} xpm={2} />
 
         </UserCardWrapper>
     </MiniCard>

--- a/src/components/UserCards/index.tsx
+++ b/src/components/UserCards/index.tsx
@@ -158,7 +158,7 @@ const UserCards: React.FC<{
                     </Row>
                 </>
             }
-            <DeluxePaymentModal open={showAddCard} onClose={() => setShowAddCard(false)} onPaymentAdd={handleOnCardAdd} />
+            <DeluxePaymentModal open={showAddCard} onClose={() => setShowAddCard(false)} onPaymentAdd={handleOnCardAdd} xpm={1} />
         </UserCardWrapper>
     </MiniCard>
 }

--- a/src/pages/Collect/Payment/index.tsx
+++ b/src/pages/Collect/Payment/index.tsx
@@ -50,6 +50,7 @@ const Payment = () => {
     const [cards, setCards] = useState<Array<Card>>([])
     const [bankAccounts, setBankAccounts] = useState<Array<BankAccount>>([])
     const [showAddPaymentMethod, setShowAddPaymentMethod] = useState(false)
+    const [deluxeXpm, setDeluxeXpm] = useState(0)
     const successUrl = useMemo(() => userRole === Roles.AGENCY ? "/agency/collect/success" : "/payment/success", [userRole])
     const errorUrl = useMemo(() => userRole === Roles.AGENCY ? "/agency/collect/error" : "/payment/error", [userRole])
     const backUrl = useMemo(() => userRole === Roles.AGENCY ? "/agency/collect/customer-summary" : "my-bills", [userRole])
@@ -377,9 +378,9 @@ const Payment = () => {
                                                             case PaymentType.CASH:
                                                                 return <CashPayment duePayment={duePayment} />
                                                             case PaymentType.CARD:
-                                                                return <CardPayment autoPayment={enableAutoPayment} onAutoPaymentChange={setEnableAutoPayment} loading={isPaymentSourceLoading} cards={cards} onCardSelect={cardCollectionById} paymentRecordingWith={paymentRecordingWith} amount={Number(duePayment?.value)} onAddCard={() => setShowAddPaymentMethod(true)} />
+                                                                return <CardPayment autoPayment={enableAutoPayment} onAutoPaymentChange={setEnableAutoPayment} loading={isPaymentSourceLoading} cards={cards} onCardSelect={cardCollectionById} paymentRecordingWith={paymentRecordingWith} amount={Number(duePayment?.value)} onAddCard={() => { setDeluxeXpm(1); setShowAddPaymentMethod(true); }} />
                                                             case PaymentType.DIRECT_DEBIT:
-                                                                return <DirectDebitPayment autoPayment={enableAutoPayment} onAutoPaymentChange={setEnableAutoPayment} loading={isPaymentSourceLoading} bankAccounts={bankAccounts} onAccountSelect={directDebitCollectionById} paymentRecordingWith={paymentRecordingWith} amount={Number(duePayment?.value)} onAddAccount={() => setShowAddPaymentMethod(true)} />
+                                                                return <DirectDebitPayment autoPayment={enableAutoPayment} onAutoPaymentChange={setEnableAutoPayment} loading={isPaymentSourceLoading} bankAccounts={bankAccounts} onAccountSelect={directDebitCollectionById} paymentRecordingWith={paymentRecordingWith} amount={Number(duePayment?.value)} onAddAccount={() => { setDeluxeXpm(2); setShowAddPaymentMethod(true); }} />
 
                                                             default:
                                                                 return null;
@@ -401,7 +402,7 @@ const Payment = () => {
                 </Col>
             </Row>
         </BoxWrapper>
-        <DeluxePaymentModal open={showAddPaymentMethod} onClose={() => setShowAddPaymentMethod(false)} onPaymentAdd={handlePaymentMethodAdd} />
+        <DeluxePaymentModal open={showAddPaymentMethod} onClose={() => { setShowAddPaymentMethod(false); setDeluxeXpm(0); }} onPaymentAdd={handlePaymentMethodAdd} xpm={deluxeXpm} />
         </>
 
     )


### PR DESCRIPTION
## Summary
- allow DeluxePaymentModal to accept an xpm value and apply it in the hosted form options
- track selected payment method on payment page to send xpm 1 for new cards and 2 for direct debit
- use fixed xpm values in UserCards (1) and UserAccounts (2)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2848e73fc832bb94ce5583424c3a7