### PR TITLE
feat: configure deluxe payment embed

### DIFF
--- a/src/components/DeluxePaymentModal/index.tsx
+++ b/src/components/DeluxePaymentModal/index.tsx
@@ -5,12 +5,14 @@ import { useDirectUs } from '../DirectUs/DirectusContext';
 import { getAgencyDeluxePartnerToken, updateProfile } from '../../utils/apis/directus';
 import { updateAgency } from '../../utils/redux/slices/authSlice';
 import { RootState } from '../../utils/redux/store';
+import { PaymentType } from '../../utils/enums/common';
 
 const DeluxePaymentModal: React.FC<{
     open?: boolean;
     onClose?: () => void;
     onPaymentAdd?: () => void;
-}> = ({ open, onClose, onPaymentAdd }) => {
+    paymentType?: PaymentType | null;
+}> = ({ open, onClose, onPaymentAdd, paymentType }) => {
     const dispatch = useDispatch();
     const { directusClient } = useDirectUs();
     const deluxeToken = useSelector(({ auth }: RootState) => auth.agency?.deluxePartnerToken);
@@ -66,6 +68,8 @@ const DeluxePaymentModal: React.FC<{
     }, [open, onClose, onPaymentAdd, directusClient]);
 
     const iframeDoc = useMemo(() => {
+        const xpm = paymentType === PaymentType.CARD ? '1' : paymentType === PaymentType.DIRECT_DEBIT ? '2' : '0';
+        const xrType = paymentType ? 'Generate Token' : 'Create Vault';
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -98,8 +102,8 @@ const DeluxePaymentModal: React.FC<{
   var options = {
     containerId: "mycontainer",
     xtoken: "${deluxeToken}",
-    xrtype: "Create Vault",
-    xpm: "0",
+    xrtype: "${xrType}",
+    xpm: "${xpm}",
     xcssid: "mycustomcss"
   };
 
@@ -113,7 +117,7 @@ const DeluxePaymentModal: React.FC<{
 </script>
 </body>
 </html>`;
-    }, [deluxeToken]);
+    }, [deluxeToken, paymentType]);
 
     return (
         <CustomModal

--- a/src/pages/Collect/Payment/index.tsx
+++ b/src/pages/Collect/Payment/index.tsx
@@ -50,6 +50,7 @@ const Payment = () => {
     const [cards, setCards] = useState<Array<Card>>([])
     const [bankAccounts, setBankAccounts] = useState<Array<BankAccount>>([])
     const [showAddPaymentMethod, setShowAddPaymentMethod] = useState(false)
+    const [deluxePaymentType, setDeluxePaymentType] = useState<PaymentType | null>(null)
     const successUrl = useMemo(() => userRole === Roles.AGENCY ? "/agency/collect/success" : "/payment/success", [userRole])
     const errorUrl = useMemo(() => userRole === Roles.AGENCY ? "/agency/collect/error" : "/payment/error", [userRole])
     const backUrl = useMemo(() => userRole === Roles.AGENCY ? "/agency/collect/customer-summary" : "my-bills", [userRole])
@@ -377,9 +378,15 @@ const Payment = () => {
                                                             case PaymentType.CASH:
                                                                 return <CashPayment duePayment={duePayment} />
                                                             case PaymentType.CARD:
-                                                                return <CardPayment autoPayment={enableAutoPayment} onAutoPaymentChange={setEnableAutoPayment} loading={isPaymentSourceLoading} cards={cards} onCardSelect={cardCollectionById} paymentRecordingWith={paymentRecordingWith} amount={Number(duePayment?.value)} onAddCard={() => setShowAddPaymentMethod(true)} />
+                                                                return <CardPayment autoPayment={enableAutoPayment} onAutoPaymentChange={setEnableAutoPayment} loading={isPaymentSourceLoading} cards={cards} onCardSelect={cardCollectionById} paymentRecordingWith={paymentRecordingWith} amount={Number(duePayment?.value)} onAddCard={() => {
+                                                                    setDeluxePaymentType(PaymentType.CARD)
+                                                                    setShowAddPaymentMethod(true)
+                                                                }} />
                                                             case PaymentType.DIRECT_DEBIT:
-                                                                return <DirectDebitPayment autoPayment={enableAutoPayment} onAutoPaymentChange={setEnableAutoPayment} loading={isPaymentSourceLoading} bankAccounts={bankAccounts} onAccountSelect={directDebitCollectionById} paymentRecordingWith={paymentRecordingWith} amount={Number(duePayment?.value)} onAddAccount={() => setShowAddPaymentMethod(true)} />
+                                                                return <DirectDebitPayment autoPayment={enableAutoPayment} onAutoPaymentChange={setEnableAutoPayment} loading={isPaymentSourceLoading} bankAccounts={bankAccounts} onAccountSelect={directDebitCollectionById} paymentRecordingWith={paymentRecordingWith} amount={Number(duePayment?.value)} onAddAccount={() => {
+                                                                    setDeluxePaymentType(PaymentType.DIRECT_DEBIT)
+                                                                    setShowAddPaymentMethod(true)
+                                                                }} />
 
                                                             default:
                                                                 return null;
@@ -401,7 +408,15 @@ const Payment = () => {
                 </Col>
             </Row>
         </BoxWrapper>
-        <DeluxePaymentModal open={showAddPaymentMethod} onClose={() => setShowAddPaymentMethod(false)} onPaymentAdd={handlePaymentMethodAdd} />
+        <DeluxePaymentModal
+            open={showAddPaymentMethod}
+            onClose={() => {
+                setShowAddPaymentMethod(false)
+                setDeluxePaymentType(null)
+            }}
+            onPaymentAdd={handlePaymentMethodAdd}
+            paymentType={deluxePaymentType}
+        />
         </>
 
     )


### PR DESCRIPTION
## Summary
- adjust DeluxePaymentModal to set `xpm` and `xrtype` based on payment type
- send payment type from Collect Payment page to differentiate card vs direct debit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a289ee6d00832b84e7385c2ec7593d