### PR TITLE
Include customer and agency IDs in Deluxe flow payloads

### DIFF
--- a/src/pages/Collect/Payment/index.tsx
+++ b/src/pages/Collect/Payment/index.tsx
@@ -107,10 +107,15 @@ const Payment = () => {
             try {
                 const agencyId = typeof duePayment.agency === 'object' ? (duePayment.agency as DirectusAgency).id : duePayment.agency;
                 if (tokenData) {
+                    const payload = {
+                        ...tokenData,
+                        customer_id: duePayment.customer as string,
+                        agency: String(agencyId)
+                    };
                     if (deluxePaymentType === PaymentType.CARD) {
-                        await deluxeCreateNewCard(directusClient, tokenData);
+                        await deluxeCreateNewCard(directusClient, payload);
                     } else if (deluxePaymentType === PaymentType.DIRECT_DEBIT) {
-                        await deluxeCreateNewACH(directusClient, tokenData);
+                        await deluxeCreateNewACH(directusClient, payload);
                     }
                 }
                 await stageCustomerPaymentMethod(directusClient, {

--- a/src/utils/apis/directus/index.ts
+++ b/src/utils/apis/directus/index.ts
@@ -449,6 +449,8 @@ export const deluxeCreateNewCard = async (
         expDate: string,
         maskedPan: string,
         cardType: string,
+        customer_id: string,
+        agency: string,
     }
 ) => {
     try {
@@ -473,6 +475,8 @@ export const deluxeCreateNewACH = async (
         expDate: string,
         maskedPan: string,
         cardType: string,
+        customer_id: string,
+        agency: string,
     }
 ) => {
     try {


### PR DESCRIPTION
## Summary
- add customer_id and agency to Deluxe card/ACH flow payloads
- send customer and agency identifiers when adding new payment methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a29d25c5fc832ba9478c217ebfaabd