### PR TITLE
Ensure payment methods are staged before retrieval

### DIFF
--- a/src/pages/Collect/Payment/index.tsx
+++ b/src/pages/Collect/Payment/index.tsx
@@ -59,8 +59,14 @@ const Payment = () => {
             if (duePayment?.agency && duePayment.customer) {
                 try {
                     setIsPaymentSourceLoading(true)
+                    const agencyId = typeof duePayment.agency === 'object' ? (duePayment.agency as DirectusAgency).id : duePayment.agency
+                    // ensure directus stages latest payment methods before fetching them
+                    await stageCustomerPaymentMethod(directusClient, {
+                        customer_id: duePayment.customer as string,
+                        agency: String(agencyId)
+                    })
                     const res: any[] = await fetchCustomerAgencyFlowNew(directusClient, {
-                        agency: String(duePayment.agency),
+                        agency: String(agencyId),
                         customer_id: duePayment.customer as string
                     })
                     const customerMethods = res.filter(pm => pm.owner === duePayment.customer)


### PR DESCRIPTION
## Summary
- stage payment methods before fetching them to ensure latest flow data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2af62ae4c832ba280f2a1b053e125