### PR TITLE
fix: avoid logout on payment errors

### DIFF
--- a/src/utils/errors/parseDirectUsErrors.ts
+++ b/src/utils/errors/parseDirectUsErrors.ts
@@ -20,8 +20,10 @@ const parseDirectUsErrors = (error: DirectusError) => {
             return new InvalidCredentialsError()
         case "BAD_REQUEST":
             return new BadRequestError(message)
-        case "FORBIDDEN":
+        case "UNAUTHENTICATED":
             performLogout()
+            return new ForbiddenError()
+        case "FORBIDDEN":
             return new ForbiddenError()
         default:
             return new SomethingWentWrongError(message)


### PR DESCRIPTION
## Summary
- stop logging users out when Directus returns a forbidden error
- only logout on unauthenticated responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3baa72bd0832baaf52188ca27da2b