### PR TITLE
feat: add directus static token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Environment Variables
+
+The application expects the following Directus configuration variables to be defined:
+
+- `REACT_APP_DIRECTUS_URL` – Base URL of the Directus instance.
+- `REACT_APP_DIRECTUS_STATIC_TOKEN` – Public API token used to access Directus for unauthenticated users.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/components/DirectUs/DirectusContext.tsx
+++ b/src/components/DirectUs/DirectusContext.tsx
@@ -1,4 +1,4 @@
-import { authentication, AuthenticationData, createDirectus, rest } from '@directus/sdk';
+import { authentication, AuthenticationData, createDirectus, rest, staticToken } from '@directus/sdk';
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
 import { DirectusContextClient } from '../../utils/types/directus';
 import { Schema } from '../../utils/types/schema';
@@ -24,7 +24,8 @@ export const useDirectUs = () => {
 
 export const DirectusProvider: React.FC<DirectusProviderProps> = ({ children }) => {
     const providerValue = useMemo(() => ({
-        directusClient: createDirectus<Schema>('https://meansfinance.directus.app/')
+        directusClient: createDirectus<Schema>(process.env.REACT_APP_DIRECTUS_URL!)
+            .with(staticToken(process.env.REACT_APP_DIRECTUS_STATIC_TOKEN!))
             .with(
                 authentication(
                     'json',
@@ -32,20 +33,20 @@ export const DirectusProvider: React.FC<DirectusProviderProps> = ({ children }) 
                         autoRefresh: true,
                         storage: {
                             get: () => {
-                                const data = localStorage.getItem('authenticationData')
+                                const data = localStorage.getItem('authenticationData');
                                 if (data) {
-                                    return JSON.parse(data)
+                                    return JSON.parse(data);
                                 }
-                                return null
+                                return null;
                             },
-                            set: (value: AuthenticationData | null) => localStorage.setItem('authenticationData', JSON.stringify(value))
+                            set: (value: AuthenticationData | null) =>
+                                localStorage.setItem('authenticationData', JSON.stringify(value))
                         }
                     }
                 )
-            ).with(
-                rest()
             )
-    }), [])
+            .with(rest())
+    }), []);
     return (
         <DirectusContext.Provider value={providerValue}>
             {children}


### PR DESCRIPTION
## Summary
- allow Directus client to use a static token for unauthenticated access
- document Directus URL and static token env vars

## Testing
- `npm test`
- `node -e "const { createDirectus, rest, staticToken, readMe } = require('@directus/sdk'); const client = createDirectus(process.env.REACT_APP_DIRECTUS_URL || 'https://meansfinance.directus.app/').with(staticToken(process.env.REACT_APP_DIRECTUS_STATIC_TOKEN || 'invalid')).with(rest()); client.request(readMe()).then(r => console.log('success', r)).catch(err => console.error('error', err?.response?.status, err?.message));"` *(fails: fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_68a3d9e44bb8832bb1fa1935ca408660