### PR TITLE
feat: show ACH account type

### DIFF
--- a/src/components/UserAccounts/index.tsx
+++ b/src/components/UserAccounts/index.tsx
@@ -41,10 +41,10 @@ const UserAccounts: React.FC<{
         </AccountInfo>
         <AccountInfo>
             <div className="label">
-                Account #
+                Account Type
             </div>
             <div className="value">
-                {props.account.account_number.replaceAll("*", ".")}
+                {props.account.account_type}
             </div>
         </AccountInfo>
         {selectMode &&

--- a/src/pages/Collect/Payment/index.tsx
+++ b/src/pages/Collect/Payment/index.tsx
@@ -88,7 +88,7 @@ const Payment = () => {
                             id: pm.payment_method_id,
                             is_default: 0,
                             routing_number: Number(pm.routing_number),
-                            account_number: pm.account_number
+                            account_type: pm.account_type
                         }))
                     setCards(fetchedCards)
                     setBankAccounts(fetchedAccounts)

--- a/src/pages/MyBills/index.tsx
+++ b/src/pages/MyBills/index.tsx
@@ -53,7 +53,7 @@ const MyBills: React.FC = () => {
                             id: pm.payment_method_id,
                             is_default: 0,
                             routing_number: Number(pm.routing_number),
-                            account_number: pm.account_number
+                            account_type: pm.account_type
                         }))
                     setCards(fetchedCards)
                     setBankAccounts(fetchedAccounts)

--- a/src/utils/types/common.ts
+++ b/src/utils/types/common.ts
@@ -88,6 +88,6 @@ export type BankAccount = {
     id: string;
     is_default: 1 | 0;
     routing_number: number;
-    account_number: string;
+    account_type: string;
 }
 export type PaymentRecordingWith = { type: PaymentType | null, id: string | null }


### PR DESCRIPTION
## Summary
- display bank account type instead of account number for ACH payment methods
- adapt bank account type definitions and mappings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd5afca00832b956a710b1e8a4168