### PR TITLE
Separate My Bills payment modals

### DIFF
--- a/src/components/CustomerDeluxePaymentModal/index.tsx
+++ b/src/components/CustomerDeluxePaymentModal/index.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useState } from 'react';
+import CustomModal from '../CustomModal';
+import { useDirectUs } from '../DirectUs/DirectusContext';
+import { getAgencyDeluxePartnerToken, updateProfile } from '../../utils/apis/directus';
+import { PaymentType } from '../../utils/enums/common';
+
+export interface DeluxeTokenData {
+    token: string;
+    nameOnCard: string;
+    expDate: string;
+    maskedPan: string;
+    cardType: string;
+}
+
+const CustomerDeluxePaymentModal: React.FC<{
+    open?: boolean;
+    onClose?: () => void;
+    onPaymentAdd?: (data?: DeluxeTokenData) => void;
+    paymentType?: PaymentType | null;
+    agencyId: number | null;
+}> = ({ open, onClose, onPaymentAdd, paymentType, agencyId }) => {
+    const { directusClient } = useDirectUs();
+    const [deluxeToken, setDeluxeToken] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchToken = async () => {
+            if (agencyId && !deluxeToken) {
+                try {
+                    const token = await getAgencyDeluxePartnerToken(directusClient, agencyId);
+                    setDeluxeToken(token);
+                } catch (err) {
+                    console.error(err);
+                }
+            }
+        };
+        if (open) {
+            fetchToken();
+        }
+    }, [open, agencyId, deluxeToken, directusClient]);
+
+    useEffect(() => {
+        const handleMessage = async (e: MessageEvent) => {
+            const data = e.data as any;
+            const isVaultMessage = data && typeof data === 'object' && data.type === 'Vault';
+            const isSuccessEvent = data && typeof data === 'object' && data.event === 'deluxe_success';
+            const isTokenMessage = isSuccessEvent && data.payload?.type === 'Token';
+
+            if (isTokenMessage) {
+                if (onPaymentAdd) {
+                    onPaymentAdd(data.payload?.data);
+                }
+                if (onClose) {
+                    onClose();
+                }
+                return;
+            }
+
+            if (isSuccessEvent || isVaultMessage) {
+                const payload = isVaultMessage
+                    ? { customerId: data.data?.customerId, vaultId: data.data?.vaultId }
+                    : data.payload;
+                sessionStorage.setItem('deluxeData', JSON.stringify(payload));
+                try {
+                    if (payload?.data?.customerId || payload?.data?.vaultId) {
+                        await updateProfile(directusClient, {
+                            deluxe_customer_id: payload?.data?.customerId,
+                            deluxe_vault_id: payload?.data?.vaultId,
+                        });
+                    }
+                } catch (err) {
+                    console.error(err);
+                }
+                if (onPaymentAdd) {
+                    onPaymentAdd();
+                }
+                if (onClose) {
+                    onClose();
+                }
+            }
+        };
+        if (open) {
+            window.addEventListener('message', handleMessage);
+        }
+        return () => window.removeEventListener('message', handleMessage);
+    }, [open, onClose, onPaymentAdd, directusClient]);
+
+    const iframeDoc = useMemo(() => {
+        const xpm = paymentType === PaymentType.CARD ? '1' : paymentType === PaymentType.DIRECT_DEBIT ? '2' : '0';
+        const xrType = paymentType ? 'Generate Token' : 'Create Vault';
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script src="https://hostedpaymentform.deluxe.com/v2/deluxe.js"></script>
+  <style id="mycustomcss">
+    body {
+      padding: 24px;
+      border-radius: 25px;
+      height: 100%;
+    }
+    .form-control {
+      color: green;
+      border: 1px solid #0d6efd;
+    }
+    .form-label {
+      color: black;
+    }
+    .btn {
+      color: green;
+      border: 1px solid green;
+    }
+    .iframe-wrapper #dppPaymentContainer {
+      height: 100% !important;
+    }
+  </style>
+</head>
+<body>
+<div id="mycontainer"></div>
+<script>
+  var options = {
+    containerId: "mycontainer",
+    xtoken: "${deluxeToken}",
+    xrtype: "${xrType}",
+    xpm: "${xpm}",
+    xcssid: "mycustomcss"
+  };
+
+  HostedForm.init(options, {
+    onSuccess: function(data) {
+      window.parent.postMessage({event:'deluxe_success', payload:data}, '*');
+    },
+    onFailure: function(data) { console.log(JSON.stringify(data)); },
+    onInvalid: function(data) { console.log(JSON.stringify(data)); }
+  }).then(function(instance) { instance.renderHpf(); });
+</script>
+</body>
+</html>`;
+    }, [deluxeToken, paymentType]);
+
+    return (
+        <CustomModal
+            title="Add Payment Method"
+            open={open}
+            onCancel={onClose}
+            onClose={onClose}
+            footer={false}
+            width={700}
+        >
+            <iframe
+                title="Deluxe Payment"
+                srcDoc={iframeDoc}
+                style={{ width: '100%', border: 'none', height: '700px' }}
+            />
+        </CustomModal>
+    );
+};
+
+export default CustomerDeluxePaymentModal;

--- a/src/components/UserAccounts/index.tsx
+++ b/src/components/UserAccounts/index.tsx
@@ -11,6 +11,7 @@ import { LoadingSpinner } from "../LoadingSpinner";
 import MiniCard from "../MiniCard";
 import { AddButton, CardChangeButtonWrapper, CardWrapper, StyledCarousel, UserCardHeading, UserCardWrapper } from '../UserCards/style';
 import DeluxePaymentModal, { DeluxeTokenData } from "../DeluxePaymentModal";
+import CustomerDeluxePaymentModal from "../CustomerDeluxePaymentModal";
 import NoAccounts from "./NoCard";
 import { AccountInfo } from "./style";
 import { deluxeCreateNewACH } from "../../utils/apis/directus";
@@ -25,7 +26,8 @@ const UserAccounts: React.FC<{
     onSelect?: (cardId: string) => void
     paymentRecordingWith?: PaymentRecordingWith
     selectedAccountId?: string
-}> = ({ loading, bankAccounts, agencyId, refetch, selectMode, onSelect, paymentRecordingWith, selectedAccountId }) => {
+    useCustomerModal?: boolean
+}> = ({ loading, bankAccounts, agencyId, refetch, selectMode, onSelect, paymentRecordingWith, selectedAccountId, useCustomerModal }) => {
     const { directusClient } = useDirectUs()
     const userId = useSelector((state: RootState) => state.auth.user?.id)
     const [showAddAccount, setShowAddAccount] = useState(false)
@@ -126,7 +128,22 @@ const UserAccounts: React.FC<{
                     </Row>
                 </>
             }
-            <DeluxePaymentModal open={showAddAccount} onClose={() => setShowAddAccount(false)} onPaymentAdd={handleOnAccountAdd} paymentType={PaymentType.DIRECT_DEBIT} />
+            {useCustomerModal ? (
+                <CustomerDeluxePaymentModal
+                    open={showAddAccount}
+                    onClose={() => setShowAddAccount(false)}
+                    onPaymentAdd={handleOnAccountAdd}
+                    paymentType={PaymentType.DIRECT_DEBIT}
+                    agencyId={agencyId}
+                />
+            ) : (
+                <DeluxePaymentModal
+                    open={showAddAccount}
+                    onClose={() => setShowAddAccount(false)}
+                    onPaymentAdd={handleOnAccountAdd}
+                    paymentType={PaymentType.DIRECT_DEBIT}
+                />
+            )}
 
         </UserCardWrapper>
     </MiniCard>

--- a/src/components/UserCards/index.tsx
+++ b/src/components/UserCards/index.tsx
@@ -15,6 +15,7 @@ import CustomButton1 from "../Form/CustomButton1";
 import { LoadingSpinner } from "../LoadingSpinner";
 import MiniCard from "../MiniCard";
 import DeluxePaymentModal, { DeluxeTokenData } from "../DeluxePaymentModal";
+import CustomerDeluxePaymentModal from "../CustomerDeluxePaymentModal";
 import NoCard from "./NoCard";
 import { AddButton, CardChangeButtonWrapper, CardDetailsWrapper, CardIconWrapper, CardInfoWrapper, CardWrapper, DeleteButton, DropdownContent, StyledCarousel, UserCardHeading, UserCardWrapper } from './style';
 
@@ -28,7 +29,8 @@ const UserCards: React.FC<{
     changeLoading?: (state: boolean) => void
     paymentRecordingWith?: PaymentRecordingWith
     selectedCardId?: string
-}> = ({ loading, cards, agencyId, refetch, selectMode, onSelect, changeLoading, paymentRecordingWith, selectedCardId }) => {
+    useCustomerModal?: boolean
+}> = ({ loading, cards, agencyId, refetch, selectMode, onSelect, changeLoading, paymentRecordingWith, selectedCardId, useCustomerModal }) => {
     const { directusClient } = useDirectUs()
     const userId = useSelector((state: RootState) => state.auth.user?.id)
     const [showAddCard, setShowAddCard] = useState(false)
@@ -174,7 +176,22 @@ const UserCards: React.FC<{
                     </Row>
                 </>
             }
-            <DeluxePaymentModal open={showAddCard} onClose={() => setShowAddCard(false)} onPaymentAdd={handleOnCardAdd} paymentType={PaymentType.CARD} />
+            {useCustomerModal ? (
+                <CustomerDeluxePaymentModal
+                    open={showAddCard}
+                    onClose={() => setShowAddCard(false)}
+                    onPaymentAdd={handleOnCardAdd}
+                    paymentType={PaymentType.CARD}
+                    agencyId={agencyId}
+                />
+            ) : (
+                <DeluxePaymentModal
+                    open={showAddCard}
+                    onClose={() => setShowAddCard(false)}
+                    onPaymentAdd={handleOnCardAdd}
+                    paymentType={PaymentType.CARD}
+                />
+            )}
         </UserCardWrapper>
     </MiniCard>
 }

--- a/src/pages/MyBills/index.tsx
+++ b/src/pages/MyBills/index.tsx
@@ -103,10 +103,23 @@ const MyBills: React.FC = () => {
                                 <GetPaidCard bill={bill} loading={isLoading} onUpdate={fetchUserBill} />
                             </Col>
                             <Col xs={24} lg={7}>
-                                <UserCards loading={isPaymentSourceLoading} cards={cards} agencyId={bill?.agency ? (bill.agency as DirectusAgency).id : null} refetch={fetchCardInfo} changeLoading={setIsPaymentSourceLoading} />
+                                <UserCards
+                                    loading={isPaymentSourceLoading}
+                                    cards={cards}
+                                    agencyId={bill?.agency ? (bill.agency as DirectusAgency).id : null}
+                                    refetch={fetchCardInfo}
+                                    changeLoading={setIsPaymentSourceLoading}
+                                    useCustomerModal
+                                />
                             </Col>
                             <Col xs={24} lg={7}>
-                                <UserAccounts loading={isPaymentSourceLoading} bankAccounts={bankAccounts} agencyId={bill?.agency ? (bill.agency as DirectusAgency).id : null} refetch={fetchCardInfo} />
+                                <UserAccounts
+                                    loading={isPaymentSourceLoading}
+                                    bankAccounts={bankAccounts}
+                                    agencyId={bill?.agency ? (bill.agency as DirectusAgency).id : null}
+                                    refetch={fetchCardInfo}
+                                    useCustomerModal
+                                />
                             </Col>
                         </>
                     }


### PR DESCRIPTION
## Summary
- add CustomerDeluxePaymentModal to fetch tokens via agency ID
- allow UserCards and UserAccounts to switch between agency and customer modals
- enable My Bills page to use customer-specific modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abdae9d078832b952f82cc930aa2c5