### PR TITLE
fix: await auth token before refreshing

### DIFF
--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -1,8 +1,11 @@
 import { DirectusContextClient } from '../utils/types/directus';
 
+// Ensure the Directus client has a valid auth token. If a token exists
+// attempt to refresh it, otherwise signal that the session is missing.
 export async function ensureAuthenticated(client: DirectusContextClient) {
   try {
-    if (client.getToken()) {
+    const token = await client.getToken();
+    if (token) {
       await client.refresh();
       return;
     }


### PR DESCRIPTION
## Summary
- await `client.getToken()` before refreshing to avoid always-true condition
- add inline comment documenting auth refresh behavior

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abed9745e0832b8230fce6ba8f155b