### PR TITLE
Limit Directus user fields during name search

### DIFF
--- a/src/utils/apis/directus/index.ts
+++ b/src/utils/apis/directus/index.ts
@@ -357,7 +357,8 @@ export const searchCustomerByName = async (client: DirectusContextClient, query:
             }
         }
         const res = await authRequest(client, readUsers({
-            filter
+            filter,
+            fields: ['id', 'first_name', 'last_name', 'phone', 'email']
         }))
         return res as CustomDirectusUser[]
     } catch (error) {


### PR DESCRIPTION
## Summary
- restrict Directus user search to necessary fields to avoid unauthorized access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf00a5ad4832ba64b5bc3b3e612cd