### PR TITLE
Fix ExistingCustomer lazy import path

### DIFF
--- a/src/utils/router/router.tsx
+++ b/src/utils/router/router.tsx
@@ -23,7 +23,7 @@ const CustomerInfo = lazyWithRetry(() => import('../../pages/Quote/CustomerInfo'
 const Summary = lazyWithRetry(() => import('../../pages/Quote/Summary'))
 const BillSummary = lazyWithRetry(() => import('../../pages/Quote/BillSummary'))
 const DeluxePayment = lazyWithRetry(() => import('../../pages/Quote/DeluxePayment'))
-const ExistingCustomer = lazyWithRetry(() => import('../../pages/Quote/ExistingCustomer'))
+const ExistingCustomer = lazyWithRetry(() => import('../../pages/Quote/ExistingCustomer/index'))
 const Quote = lazyWithRetry(() => import('../../pages/Quote'))
 const Collect = lazyWithRetry(() => import('../../pages/Collect'))
 const CollectSearch = lazyWithRetry(() => import('../../pages/Collect/Search'))


### PR DESCRIPTION
## Summary
- fix the lazy import for the existing customer quote route to explicitly resolve the index file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9e6bdc70832bb15e78d3f0d39127