### PR TITLE
Allow multiple active bills per policy

### DIFF
--- a/src/pages/Quote/CustomerInfo/index.tsx
+++ b/src/pages/Quote/CustomerInfo/index.tsx
@@ -195,8 +195,13 @@ const CustomerInfo: React.FC = () => {
                     return
                 }
                 const alreadyDueBills = await getCustomerDueBillsByCustomerId(directusClient, customer.id)
-                if (alreadyDueBills && alreadyDueBills.length > 0) {
-                    message.error("Customer is already having one due policy.")
+                const normalizedIncomingPolicyId = values.policyId?.trim().toLowerCase()
+                const hasBillWithSamePolicy = normalizedIncomingPolicyId
+                    ? alreadyDueBills?.some(bill => bill.policy_id?.trim().toLowerCase() === normalizedIncomingPolicyId)
+                    : false
+
+                if (hasBillWithSamePolicy) {
+                    message.error('Customer already has an active bill for this policy.')
                     return
                 }
                 const calculatedQuoteInfo = billDueCalculation(quote)


### PR DESCRIPTION
## Summary
- allow creating a new bill even when the customer already has other active bills
- only block bill creation when an existing confirmed bill uses the same policy ID

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd9b7bc1e8832b9dadb70c174bb941