### PR TITLE
Fix Deluxe payment dispatch payload typing

### DIFF
--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -10,6 +10,7 @@ import { updateAgency } from '../../../utils/redux/slices/authSlice';
 import { RootState } from '../../../utils/redux/store';
 import { getAgencyDeluxePartnerToken } from '../../../utils/apis/directus';
 import { PageHeader } from '../../style';
+import type { StoreQuote } from '../../../utils/types/common';
 
 const DeluxePayment: React.FC = () => {
     const navigate = useNavigate();
@@ -40,13 +41,14 @@ const DeluxePayment: React.FC = () => {
     };
 
     const handleNextClick = () => {
-        dispatch(updateQuote({ customerSelection: 'new' }));
+        const nextQuoteUpdate: Partial<StoreQuote> = { customerSelection: 'new' };
+        dispatch(updateQuote(nextQuoteUpdate));
         navigate('/agency/quote/customer-info');
     };
 
     const handleSkipClick = () => {
         sessionStorage.removeItem('deluxeData');
-        dispatch(updateQuote({
+        const skipQuoteUpdate: Partial<StoreQuote> = {
             customerSelection: 'existing',
             existingCustomerId: null,
             existingCustomerDeluxeCustomerId: null,
@@ -55,7 +57,8 @@ const DeluxePayment: React.FC = () => {
             customerFirstName: null,
             customerLastName: null,
             customerPhone: null,
-        }));
+        };
+        dispatch(updateQuote(skipQuoteUpdate));
         navigate('/agency/quote/existing-customer');
     };
 


### PR DESCRIPTION
## Summary
- type annotate the Deluxe payment quote update payloads with the StoreQuote shape
- reuse the typed payloads when dispatching updateQuote so TypeScript recognises the structure

## Testing
- npx tsc --noEmit *(fails: Directus SDK type definitions require a newer TypeScript version to parse `const` type parameters)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb9fccf0832b9cc04e43bada92bb