### PR TITLE
Improve payment status handling for payment history

### DIFF
--- a/src/pages/Collect/CustomerSummary/index.tsx
+++ b/src/pages/Collect/CustomerSummary/index.tsx
@@ -109,12 +109,16 @@ const CustomerSummary = () => {
             if (bill?.id) {
                 const directusPayments = await getBillPayments(directusClient, bill.id)
 
-                const paymentsWithStatus = directusPayments.map(payment => ({
-                    ...payment,
-                    status: normalizePaymentStatus(payment) ?? payment.status
-                }))
+                const paymentsWithStatus = directusPayments.map(payment => {
+                    const normalizedStatus = normalizePaymentStatus(payment)
 
-                const hasUpcomingPayment = paymentsWithStatus.some(payment => (payment.status ?? '').toLowerCase() === 'upcoming')
+                    return {
+                        ...payment,
+                        status: normalizedStatus ?? (payment.status ? payment.status.toLowerCase() : payment.status)
+                    }
+                })
+
+                const hasUpcomingPayment = paymentsWithStatus.some(payment => normalizePaymentStatus(payment) === 'upcoming')
                 const upcomingPayment = !hasUpcomingPayment && bill.next_installment_date
                     ? {
                         status: "upcoming" as DirectusPayment['status'],

--- a/src/pages/Collect/CustomerSummary/index.tsx
+++ b/src/pages/Collect/CustomerSummary/index.tsx
@@ -145,10 +145,6 @@ const CustomerSummary = () => {
                     }
 
                     const normalizedStatus = normalizePaymentStatus(payment);
-                    const rawStatus = (payment.status ?? '').trim().toLowerCase();
-                    const today = moment();
-                    const dueDate = payment.due_date ? moment(payment.due_date) : null;
-                    const isFutureDueDate = dueDate ? dueDate.isAfter(today, 'day') : false;
 
                     if (normalizedStatus === 'pending' || normalizedStatus === 'paid') {
                         return false;
@@ -156,8 +152,7 @@ const CustomerSummary = () => {
 
                     return normalizedStatus === 'missed'
                         || normalizedStatus === 'upcoming'
-                        || rawStatus.length === 0
-                        || isFutureDueDate;
+                        || normalizedStatus === null;
                 };
 
                 const payablePayment = isPayable(selectedPayment)

--- a/src/pages/Manage/PaymentHistory.tsx
+++ b/src/pages/Manage/PaymentHistory.tsx
@@ -134,16 +134,11 @@ const PaymentHistory: React.FC<{
             align: 'right',
             render: (_, record) => {
                 const status = normalizePaymentStatus(record)
-                const rawStatus = (record.status ?? '').trim().toLowerCase()
-                const today = moment()
-                const dueDate = record.due_date ? moment(record.due_date) : null
-                const isFutureDueDate = dueDate ? dueDate.isAfter(today, 'day') : false
                 const canPayNow = record.id > 0
                     && (
                         status === 'missed'
                         || status === 'upcoming'
-                        || rawStatus.length === 0
-                        || isFutureDueDate
+                        || status === null
                     )
 
                 return canPayNow

--- a/src/pages/Manage/PaymentHistory.tsx
+++ b/src/pages/Manage/PaymentHistory.tsx
@@ -32,28 +32,8 @@ const PaymentHistory: React.FC<{
             setPaymentsLoading(true)
             if (bill?.id) {
                 const paymentsRes = await getBillPayments(directusClient, bill.id)
-                const hasUpcomingPayment = paymentsRes.some(payment => normalizePaymentStatus(payment) === 'upcoming')
 
-                const data = (!hasUpcomingPayment && bill?.next_installment_date)
-                    ? [
-                        {
-                            status: null,
-                            id: -1,
-                            bill: null,
-                            down_payment: false,
-                            due_date: bill.next_installment_date,
-                            paid_date: null,
-                            method: null,
-                            customer: null,
-                            value: `${Number(bill.installments) - Number(bill.credit_amount ?? 0)}`,
-                            cash_payment: null,
-                            agency: null
-                        } as DirectusPayment,
-                        ...paymentsRes
-                    ]
-                    : paymentsRes
-
-                setDataSource(data)
+                setDataSource(paymentsRes)
             } else {
                 setDataSource([])
             }
@@ -134,11 +114,12 @@ const PaymentHistory: React.FC<{
             align: 'right',
             render: (_, record) => {
                 const status = normalizePaymentStatus(record)
+                const rawStatus = (record.status ?? '').trim().toLowerCase()
                 const canPayNow = record.id > 0
                     && (
                         status === 'missed'
                         || status === 'upcoming'
-                        || status === null
+                        || rawStatus === ''
                     )
 
                 return canPayNow

--- a/src/pages/Manage/PaymentHistory.tsx
+++ b/src/pages/Manage/PaymentHistory.tsx
@@ -32,11 +32,15 @@ const PaymentHistory: React.FC<{
             setPaymentsLoading(true)
             if (bill?.id) {
                 const paymentsRes = await getBillPayments(directusClient, bill.id)
-                const normalizedPayments = paymentsRes.map(payment => ({
-                    ...payment,
-                    status: normalizePaymentStatus(payment) ?? payment.status
-                }))
-                const hasUpcomingPayment = normalizedPayments.some(payment => (payment.status ?? '').toLowerCase() === 'upcoming')
+                const normalizedPayments = paymentsRes.map(payment => {
+                    const normalizedStatus = normalizePaymentStatus(payment)
+
+                    return {
+                        ...payment,
+                        status: normalizedStatus ?? (payment.status ? payment.status.toLowerCase() : payment.status)
+                    }
+                })
+                const hasUpcomingPayment = normalizedPayments.some(payment => normalizePaymentStatus(payment) === 'upcoming')
 
                 const data = (!hasUpcomingPayment && bill?.next_installment_date)
                     ? [

--- a/src/pages/MyBills/NextBillCard.tsx
+++ b/src/pages/MyBills/NextBillCard.tsx
@@ -11,6 +11,7 @@ import { InternalErrors } from '../../utils/types/errors'
 import { DirectusBill, DirectusPayment } from "../../utils/types/schema"
 import { StatusWrapper } from '../style'
 import { NextBillAmountWrapper, NextBillCardWrapper, NextBillDueDate, NextBillHeading } from "./style"
+import normalizePaymentStatus from '../../utils/helpers/normalizePaymentStatus'
 
 const NextBillCard: React.FC<{
     bill?: DirectusBill | null
@@ -24,8 +25,10 @@ const NextBillCard: React.FC<{
             try {
                 setLoading(true)
                 const paymentRes = await getLatestPaymentOfBill(directusClient, bill?.id)
-                if (paymentRes && (paymentRes.status === 'pending' || paymentRes.status === 'missed')) {
-                    setDuePayment(paymentRes)
+                const normalizedStatus = paymentRes ? normalizePaymentStatus(paymentRes) : null
+
+                if (paymentRes && normalizedStatus && (normalizedStatus === 'pending' || normalizedStatus === 'missed' || normalizedStatus === 'upcoming')) {
+                    setDuePayment({ ...paymentRes, status: normalizedStatus })
                 } else {
                     setDuePayment(null)
                 }

--- a/src/pages/MyBills/PaymentHistoryModal.tsx
+++ b/src/pages/MyBills/PaymentHistoryModal.tsx
@@ -77,11 +77,12 @@ const PaymentHistoryModal: React.FC<{
             align: 'right',
             render: (_: number, record) => {
                 const status = normalizePaymentStatus(record)
+                const rawStatus = (record.status ?? '').trim().toLowerCase()
                 const canPayNow = record.id > 0
                     && (
                         status === 'missed'
                         || status === 'upcoming'
-                        || status === null
+                        || rawStatus === ''
                     )
 
                 if (!canPayNow) {

--- a/src/pages/MyBills/PaymentHistoryModal.tsx
+++ b/src/pages/MyBills/PaymentHistoryModal.tsx
@@ -28,10 +28,14 @@ const PaymentHistoryModal: React.FC<{
             setPaymentsLoading(true)
             if (bill?.id) {
                 const paymentsRes = await getBillPayments(directusClient, bill.id)
-                const normalizedPayments = paymentsRes.map(payment => ({
-                    ...payment,
-                    status: normalizePaymentStatus(payment) ?? payment.status
-                }))
+                const normalizedPayments = paymentsRes.map(payment => {
+                    const normalizedStatus = normalizePaymentStatus(payment)
+
+                    return {
+                        ...payment,
+                        status: normalizedStatus ?? (payment.status ? payment.status.toLowerCase() : payment.status)
+                    }
+                })
                 setDataSource(normalizedPayments)
             } else {
                 setDataSource([])

--- a/src/pages/MyBills/PaymentHistoryModal.tsx
+++ b/src/pages/MyBills/PaymentHistoryModal.tsx
@@ -77,16 +77,11 @@ const PaymentHistoryModal: React.FC<{
             align: 'right',
             render: (_: number, record) => {
                 const status = normalizePaymentStatus(record)
-                const rawStatus = (record.status ?? '').trim().toLowerCase()
-                const today = moment()
-                const dueDate = record.due_date ? moment(record.due_date) : null
-                const isFutureDueDate = dueDate ? dueDate.isAfter(today, 'day') : false
                 const canPayNow = record.id > 0
                     && (
                         status === 'missed'
                         || status === 'upcoming'
-                        || rawStatus.length === 0
-                        || isFutureDueDate
+                        || status === null
                     )
 
                 if (!canPayNow) {

--- a/src/utils/helpers/normalizePaymentStatus.ts
+++ b/src/utils/helpers/normalizePaymentStatus.ts
@@ -1,13 +1,20 @@
 import moment from 'moment';
 import { DirectusPayment } from '../types/schema';
 
+const TRUSTED_STATUSES = new Set(['missed', 'pending', 'paid', 'upcoming']);
+const PENDING_SYNONYMS = new Set(['processing', 'in_progress']);
+
 const normalizePaymentStatus = (
     payment: Pick<DirectusPayment, 'status' | 'due_date' | 'paid_date'>,
 ): string | null => {
-    const status = (payment.status ?? '').trim().toLowerCase();
+    const rawStatus = (payment.status ?? '').trim().toLowerCase();
 
-    if (status) {
-        return status;
+    if (TRUSTED_STATUSES.has(rawStatus)) {
+        return rawStatus;
+    }
+
+    if (PENDING_SYNONYMS.has(rawStatus)) {
+        return 'pending';
     }
 
     if (payment.paid_date) {
@@ -15,23 +22,23 @@ const normalizePaymentStatus = (
     }
 
     if (payment.due_date) {
-        const dueDate = moment(payment.due_date).endOf('day');
-        const now = moment();
+        const dueDate = moment(payment.due_date);
+        const today = moment();
 
-        if (dueDate.isAfter(now)) {
-            return 'upcoming';
+        if (dueDate.isBefore(today, 'day')) {
+            return 'missed';
         }
 
-        if (dueDate.isSame(now, 'day')) {
+        if (dueDate.isSame(today, 'day')) {
             return 'pending';
         }
 
-        if (dueDate.isBefore(now)) {
-            return 'missed';
+        if (dueDate.isAfter(today, 'day')) {
+            return 'upcoming';
         }
     }
 
-    return null;
+    return rawStatus || null;
 };
 
 export default normalizePaymentStatus;

--- a/src/utils/helpers/normalizePaymentStatus.ts
+++ b/src/utils/helpers/normalizePaymentStatus.ts
@@ -14,20 +14,24 @@ const normalizePaymentStatus = (
         return 'missed';
     }
 
-    if (payment.due_date) {
-        const dueDate = moment(payment.due_date);
-        const today = moment();
-
-        if (dueDate.isAfter(today, 'day')) {
-            return 'upcoming';
-        }
-    }
-
     if (rawStatus === 'pending') {
         return 'pending';
     }
 
-    return rawStatus || null;
+    if (!rawStatus) {
+        if (payment.due_date) {
+            const dueDate = moment(payment.due_date);
+            const today = moment();
+
+            if (dueDate.isAfter(today, 'day')) {
+                return 'upcoming';
+            }
+        }
+
+        return null;
+    }
+
+    return rawStatus;
 };
 
 export default normalizePaymentStatus;

--- a/src/utils/helpers/normalizePaymentStatus.ts
+++ b/src/utils/helpers/normalizePaymentStatus.ts
@@ -1,0 +1,37 @@
+import moment from 'moment';
+import { DirectusPayment } from '../types/schema';
+
+const normalizePaymentStatus = (
+    payment: Pick<DirectusPayment, 'status' | 'due_date' | 'paid_date'>,
+): string | null => {
+    const status = (payment.status ?? '').trim().toLowerCase();
+
+    if (status) {
+        return status;
+    }
+
+    if (payment.paid_date) {
+        return 'paid';
+    }
+
+    if (payment.due_date) {
+        const dueDate = moment(payment.due_date).endOf('day');
+        const now = moment();
+
+        if (dueDate.isAfter(now)) {
+            return 'upcoming';
+        }
+
+        if (dueDate.isSame(now, 'day')) {
+            return 'pending';
+        }
+
+        if (dueDate.isBefore(now)) {
+            return 'missed';
+        }
+    }
+
+    return null;
+};
+
+export default normalizePaymentStatus;

--- a/src/utils/helpers/normalizePaymentStatus.ts
+++ b/src/utils/helpers/normalizePaymentStatus.ts
@@ -1,15 +1,17 @@
 import moment from 'moment';
 import { DirectusPayment } from '../types/schema';
 
-const TRUSTED_STATUSES = new Set(['missed', 'pending', 'paid']);
-
 const normalizePaymentStatus = (
     payment: Pick<DirectusPayment, 'status' | 'due_date'>,
 ): string | null => {
     const rawStatus = (payment.status ?? '').trim().toLowerCase();
 
-    if (TRUSTED_STATUSES.has(rawStatus)) {
-        return rawStatus;
+    if (rawStatus === 'paid' || rawStatus === 'completed') {
+        return 'paid';
+    }
+
+    if (rawStatus === 'missed') {
+        return 'missed';
     }
 
     if (payment.due_date) {
@@ -19,6 +21,10 @@ const normalizePaymentStatus = (
         if (dueDate.isAfter(today, 'day')) {
             return 'upcoming';
         }
+    }
+
+    if (rawStatus === 'pending') {
+        return 'pending';
     }
 
     return rawStatus || null;

--- a/src/utils/helpers/normalizePaymentStatus.ts
+++ b/src/utils/helpers/normalizePaymentStatus.ts
@@ -1,11 +1,10 @@
 import moment from 'moment';
 import { DirectusPayment } from '../types/schema';
 
-const TRUSTED_STATUSES = new Set(['missed', 'pending', 'paid', 'upcoming']);
-const PENDING_SYNONYMS = new Set(['processing', 'in_progress']);
+const TRUSTED_STATUSES = new Set(['missed', 'pending', 'paid']);
 
 const normalizePaymentStatus = (
-    payment: Pick<DirectusPayment, 'status' | 'due_date' | 'paid_date'>,
+    payment: Pick<DirectusPayment, 'status' | 'due_date'>,
 ): string | null => {
     const rawStatus = (payment.status ?? '').trim().toLowerCase();
 
@@ -13,25 +12,9 @@ const normalizePaymentStatus = (
         return rawStatus;
     }
 
-    if (PENDING_SYNONYMS.has(rawStatus)) {
-        return 'pending';
-    }
-
-    if (payment.paid_date) {
-        return 'paid';
-    }
-
     if (payment.due_date) {
         const dueDate = moment(payment.due_date);
         const today = moment();
-
-        if (dueDate.isBefore(today, 'day')) {
-            return 'missed';
-        }
-
-        if (dueDate.isSame(today, 'day')) {
-            return 'pending';
-        }
 
         if (dueDate.isAfter(today, 'day')) {
             return 'upcoming';


### PR DESCRIPTION
## Summary
- add a shared helper to normalize payment statuses (including upcoming and pending)
- update payment history views to show normalized statuses and expose pay-now actions for missed or upcoming items
- adjust the collect customer summary to surface upcoming status pills and disable pay when the current installment is pending

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d028c194e4832bb14e48043a62e47e