### PR TITLE
Add pay-now action to customer history and bypass deluxe for renewals

### DIFF
--- a/src/pages/Collect/CustomerSummary/index.tsx
+++ b/src/pages/Collect/CustomerSummary/index.tsx
@@ -214,7 +214,7 @@ const CustomerSummary = () => {
                     : null
             }
         }
-    ], [bill?.credit_amount, bill?.installments, handlePay])
+    ], [bill, handlePay])
     const getDueDuration = (date: string) => {
         const dueDate = moment(date).endOf('day')
 
@@ -315,7 +315,12 @@ const CustomerSummary = () => {
                                         </Col>
                                     }
                                     <Col span={24}>
-                                        <PayButton onClick={handlePay} disabled={!duePayment || duePayment.status === 'pending'}>Pay</PayButton>
+                                        <PayButton
+                                            onClick={() => handlePay()}
+                                            disabled={!duePayment || duePayment.status === 'pending'}
+                                        >
+                                            Pay
+                                        </PayButton>
                                     </Col>
                                 </Row>
                             </SummaryWrapper>

--- a/src/pages/Manage/index.tsx
+++ b/src/pages/Manage/index.tsx
@@ -81,6 +81,25 @@ const Manage = () => {
                     return CustomerPayFrequency.WEEKLY
             }
         }
+        const customer = castCustomer(bill.customer);
+        if (customer?.deluxe_customer_id || customer?.deluxe_vault_id) {
+            try {
+                sessionStorage.setItem('deluxeData', JSON.stringify({
+                    data: {
+                        customerId: customer?.deluxe_customer_id,
+                        vaultId: customer?.deluxe_vault_id,
+                    }
+                }))
+            } catch (error) {
+                console.error(error)
+            }
+        } else {
+            try {
+                sessionStorage.removeItem('deluxeData')
+            } catch (error) {
+                console.error(error)
+            }
+        }
         dispatch(updateQuote({
             quoteType: bill.bill_type,
             quoteFrequency: bill.bill_recurrency,
@@ -91,12 +110,17 @@ const Manage = () => {
             weekDays: bill.weekly !== null ? Number(bill.weekly) : null,
             customerPayFrequencyDays: getPayDays(bill),
             isCustomerGetPaidOnWeekend: bill.paid_on_weekends,
-            customerEmail: castCustomer(bill.customer)?.email,
-            customerFirstName: castCustomer(bill.customer)?.first_name,
-            customerLastName: castCustomer(bill.customer)?.last_name,
-            customerPhone: castCustomer(bill.customer)?.phone,
+            customerEmail: customer?.email ?? null,
+            customerFirstName: customer?.first_name ?? null,
+            customerLastName: customer?.last_name ?? null,
+            customerPhone: customer?.phone ?? null,
             policyId: bill.policy_id,
-            vins
+            vins,
+            customerSelection: customer ? 'existing' : null,
+            existingCustomerId: customer?.id ?? null,
+            existingCustomerDeluxeCustomerId: customer?.deluxe_customer_id ?? null,
+            existingCustomerDeluxeVaultId: customer?.deluxe_vault_id ?? null,
+            isRenewal: true
         }))
         navigate('/agency/quote/bill-type')
     }

--- a/src/pages/Quote/CustomerInfo/index.tsx
+++ b/src/pages/Quote/CustomerInfo/index.tsx
@@ -218,7 +218,7 @@ const CustomerInfo: React.FC = () => {
                     })))
                 }
 
-                dispatch(updateQuote({ ...values, id: bill.id }))
+                dispatch(updateQuote({ ...values, id: bill.id, isRenewal: false }))
 
                 navigate('/agency/quote/summary')
             }

--- a/src/pages/Quote/DeluxePayment/index.spec.tsx
+++ b/src/pages/Quote/DeluxePayment/index.spec.tsx
@@ -43,7 +43,7 @@ describe('DeluxePayment Page', () => {
             auth: {
                 agency: { deluxePartnerToken: TOKEN },
             },
-            quote: {},
+            quote: { isRenewal: false },
         });
         (useNavigate as jest.Mock).mockReturnValue(navigate);
         navigate.mockClear();
@@ -67,6 +67,25 @@ describe('DeluxePayment Page', () => {
         expect(screen.getByRole('button', { name: /Skip/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /Next/i })).toBeDisabled();
         expect(screen.getByRole('button', { name: /Start Over/i })).toBeInTheDocument();
+    });
+
+    it('redirects to customer info when renewing a bill', () => {
+        store = mockStore({
+            auth: {
+                agency: { deluxePartnerToken: TOKEN },
+            },
+            quote: { isRenewal: true },
+        });
+
+        render(
+            <ThemeProvider theme={mockTheme}>
+                <Provider store={store}>
+                    <DeluxePayment />
+                </Provider>
+            </ThemeProvider>
+        );
+
+        expect(navigate).toHaveBeenCalledWith('/agency/quote/customer-info', { replace: true });
     });
 
     it('enables next button on success message and navigates when clicked', async () => {

--- a/src/pages/Quote/DeluxePayment/index.tsx
+++ b/src/pages/Quote/DeluxePayment/index.tsx
@@ -18,9 +18,19 @@ const DeluxePayment: React.FC = () => {
     const [isPaymentAdded, setIsPaymentAdded] = useState(false);
     const deluxeToken = useSelector(({ auth }: RootState) => auth.agency?.deluxePartnerToken);
     const agencyId = useSelector(({ auth }: RootState) => auth.agency?.id);
+    const isRenewal = useSelector(({ quote }: RootState) => quote.isRenewal);
     const { directusClient } = useDirectUs();
 
     useEffect(() => {
+        if (isRenewal) {
+            navigate('/agency/quote/customer-info', { replace: true });
+        }
+    }, [isRenewal, navigate]);
+
+    useEffect(() => {
+        if (isRenewal) {
+            return;
+        }
         const fetchToken = async () => {
             if (!deluxeToken && agencyId) {
                 try {
@@ -32,7 +42,7 @@ const DeluxePayment: React.FC = () => {
             }
         }
         fetchToken();
-    }, [deluxeToken, agencyId, directusClient, dispatch]);
+    }, [deluxeToken, agencyId, directusClient, dispatch, isRenewal]);
 
     const handleResetClick = () => {
         sessionStorage.removeItem('deluxeData');
@@ -70,6 +80,9 @@ const DeluxePayment: React.FC = () => {
     };
 
     useEffect(() => {
+        if (isRenewal) {
+            return;
+        }
         const handleMessage = (e: MessageEvent) => {
             const data = e.data as any;
             const isVaultMessage =
@@ -88,7 +101,7 @@ const DeluxePayment: React.FC = () => {
         };
         window.addEventListener('message', handleMessage);
         return () => window.removeEventListener('message', handleMessage);
-    }, [navigate]);
+    }, [isRenewal, navigate]);
 
     const iframeDoc = useMemo(() => {
         return `<!DOCTYPE html>
@@ -142,6 +155,10 @@ const DeluxePayment: React.FC = () => {
 </body>
 </html>`;
     }, [deluxeToken]);
+
+    if (isRenewal) {
+        return null;
+    }
 
     return (
         <Row gutter={[0, 20]} justify={"center"}>

--- a/src/utils/redux/slices/quoteSlice.ts
+++ b/src/utils/redux/slices/quoteSlice.ts
@@ -26,7 +26,8 @@ const quoteReducerInitialState: StoreQuote = {
     customerSelection: null,
     existingCustomerId: null,
     existingCustomerDeluxeCustomerId: null,
-    existingCustomerDeluxeVaultId: null
+    existingCustomerDeluxeVaultId: null,
+    isRenewal: false
 }
 export const quoteSlice = createSlice({
     name: 'auth',

--- a/src/utils/types/common.ts
+++ b/src/utils/types/common.ts
@@ -24,6 +24,7 @@ export type StoreQuote = {
     existingCustomerId: string | null
     existingCustomerDeluxeCustomerId: string | null
     existingCustomerDeluxeVaultId: string | null
+    isRenewal: boolean
 }
 
 export type StoreCollect = {


### PR DESCRIPTION
## Summary
- add a Pay now action to the customer bill history table so overdue installments can be collected directly
- track when a quote originates from a renewal and use that state to skip the Deluxe payment page while preserving customer data
- update the renewal flow to seed existing customer payment data and extend the Deluxe payment tests for the new behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d05ebe8ecc832ba2ab2fa94033e29d