### PR TITLE
Fix pay button handler type errors

### DIFF
--- a/src/pages/Collect/CustomerSummary/index.tsx
+++ b/src/pages/Collect/CustomerSummary/index.tsx
@@ -210,7 +210,7 @@ const CustomerSummary = () => {
                     && (normalizedStatus === 'missed' || normalizedStatus === 'upcoming')
 
                 return canPayNow
-                    ? <Button type='link' size='small' onClick={() => handlePay(record)}>Pay now</Button>
+                    ? <Button type='link' size='small' onClick={() => { void handlePay(record) }}>Pay now</Button>
                     : null
             }
         }
@@ -316,7 +316,7 @@ const CustomerSummary = () => {
                                     }
                                     <Col span={24}>
                                         <PayButton
-                                            onClick={() => handlePay()}
+                                            onClick={() => { void handlePay() }}
                                             disabled={!duePayment || duePayment.status === 'pending'}
                                         >
                                             Pay


### PR DESCRIPTION
## Summary
- wrap pay button click handlers so they return void while still triggering the async payment flow
- prevent the TypeScript overload mismatch that broke the Vercel build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6b4831f94832ba2ee1784396124a7